### PR TITLE
claude: effort selector via extended thinking + 5-series models

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,9 @@ const DEFAULT_MODELS: Record<ProviderId, ModelEntry[]> = {
     { id: 'gpt-5.1', name: 'GPT-5.1' },
   ],
   claude: [
+    { id: 'claude-opus-5', name: 'Claude Opus 5' },
+    { id: 'claude-sonnet-5', name: 'Claude Sonnet 5' },
+    { id: 'claude-fable-5', name: 'Claude Fable 5' },
     { id: 'claude-opus-4-5', name: 'Claude Opus 4.5', maxTokens: 64_000 },
     { id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5' },
     { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5' },

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -4,7 +4,7 @@
  * the Anthropic Messages API with the Claude Code identity headers.
  */
 
-import { EMPTY_RESPONSE_CODE, LlmAdapter, LlmError } from '@deepseek-ai/dsh-llm'
+import { EMPTY_RESPONSE_CODE, LlmAdapter, LlmError, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type {
   GenerateOptions,
   LlmModelInfo,
@@ -41,6 +41,24 @@ const CLAUDE_SCOPE = 'org:create_api_key user:profile user:inference user:sessio
 const CLAUDE_CALLBACK_PATH = '/callback'
 const CLAUDE_CONTEXT_WINDOW = 200_000
 const CLAUDE_DEFAULT_MAX_TOKENS = 32_000
+/**
+ * Reasoning effort maps to Anthropic extended thinking: the wire has no
+ * `effort` field, it has a token budget. Flat table on purpose — the tiers are
+ * a product choice, not a computed value.
+ */
+const CLAUDE_THINKING_BUDGETS: Readonly<Record<string, number>> = {
+  low: 4_096,
+  medium: 12_288,
+  high: 24_576,
+}
+/** Headroom for the answer itself once the thinking budget is reserved. */
+const CLAUDE_ANSWER_HEADROOM = 4_096
+const CLAUDE_EFFORTS = [
+  { id: ReasoningEffortId('low'), name: 'Low' },
+  { id: ReasoningEffortId('medium'), name: 'Medium' },
+  { id: ReasoningEffortId('high'), name: 'High' },
+]
+const CLAUDE_DEFAULT_EFFORT = ReasoningEffortId('medium')
 /** Refresh when the access token has less than this much life left. */
 export const CLAUDE_PREEMPT_MS = 5 * 60_000
 
@@ -333,8 +351,11 @@ export class ClaudeAdapter extends LlmAdapter {
       inputModalities: configured?.inputModalities ?? CLAUDE_MODALITIES,
       context: { contextWindow: configured?.contextWindow ?? CLAUDE_CONTEXT_WINDOW },
       defaultMaxTokens: configured?.maxTokens ?? CLAUDE_DEFAULT_MAX_TOKENS,
-      // No reasoning metadata: the subscription endpoint's thinking support is
-      // not exercised, so effort requests reject as unsupported.
+      // The subscription endpoint does serve extended thinking (verified live:
+      // `thinking` / `thinking_delta` blocks stream back with the Claude Code
+      // beta flags this provider already sends), so the route advertises the
+      // same effort selector the codex and grok routes have.
+      reasoning: { efforts: CLAUDE_EFFORTS, defaultEffort: CLAUDE_DEFAULT_EFFORT },
     })
   }
 
@@ -362,16 +383,27 @@ export class ClaudeAdapter extends LlmAdapter {
 
   private async request(options: GenerateOptions, session: ClaudeSession, signal: AbortSignal): Promise<Response> {
     const messages = await resolveImages(options.messages, this.options.resolveAttachments?.(), signal)
+    const thinkingBudget = options.reasoningEffort === undefined
+      ? undefined
+      : CLAUDE_THINKING_BUDGETS[String(options.reasoningEffort)]
+    const maxTokens = options.maxTokens
+      ?? this.options.models.find(entry => entry.id === options.model)?.maxTokens
+      ?? CLAUDE_DEFAULT_MAX_TOKENS
     const body = {
       model: options.model,
-      max_tokens: options.maxTokens
-        ?? this.options.models.find(entry => entry.id === options.model)?.maxTokens
-        ?? CLAUDE_DEFAULT_MAX_TOKENS,
+      // max_tokens covers the thinking budget too: below it the request is
+      // rejected, and at exactly the budget there is nothing left to answer with.
+      max_tokens: thinkingBudget === undefined
+        ? maxTokens
+        : Math.max(maxTokens, thinkingBudget + CLAUDE_ANSWER_HEADROOM),
       system: toAnthropicSystem(options.system, messages),
       messages: toAnthropicMessages(messages),
       ...options.tools !== undefined && options.tools.length > 0
         ? { tools: toAnthropicTools(options.tools) }
         : {},
+      ...thinkingBudget === undefined
+        ? {}
+        : { thinking: { type: 'enabled', budget_tokens: thinkingBudget } },
       stream: true,
       ...options.sessionId !== undefined ? { metadata: { user_id: String(options.sessionId) } } : {},
     }

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -529,3 +529,57 @@ test('codex resolveModel on a cold cache fetches the catalog itself', async () =
   assert.deepEqual(resolved.reasoning?.efforts.map(effort => effort.id), ['low', 'high'])
   assert.equal(resolved.context?.contextWindow, 500_000)
 })
+
+test('claude resolveModel advertises the effort selector', async () => {
+  const claude = new ClaudeAdapter({
+    models: STATIC_CLAUDE,
+    streamIdleTimeoutMs: 1000,
+    tokens: memoryTokens(claudeSession),
+  })
+  const resolved = await claude.resolveModel('claude', 'claude-opus-4-5')
+  assert.deepEqual(resolved.reasoning?.efforts.map(effort => effort.id), ['low', 'medium', 'high'])
+  assert.equal(resolved.reasoning?.defaultEffort, 'medium')
+})
+
+test('claude request: effort becomes an extended-thinking budget, max_tokens stays above it', async () => {
+  const claude = new ClaudeAdapter({
+    models: STATIC_CLAUDE,
+    streamIdleTimeoutMs: 1000,
+    tokens: memoryTokens(claudeSession),
+  })
+  const sent: Record<string, unknown>[] = []
+  const realFetch = globalThis.fetch
+  globalThis.fetch = ((_url: unknown, init: { body: string }) => {
+    sent.push(JSON.parse(init.body) as Record<string, unknown>)
+    // The body is irrelevant here: the assertion is about the request we send.
+    return Promise.resolve(new Response(null, { status: 500 }))
+  }) as typeof fetch
+
+  const drain = async (effort?: string, maxTokens?: number): Promise<void> => {
+    const options = {
+      model: 'claude-opus-4-5',
+      messages: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] }],
+      signal: new AbortController().signal,
+      ...effort === undefined ? {} : { reasoningEffort: effort },
+      ...maxTokens === undefined ? {} : { maxTokens },
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const _chunk of claude.stream(options as any)) { /* not reached */ }
+    } catch { /* 500 from the double — we only care about what was sent */ }
+  }
+
+  try {
+    await drain('high')
+    await drain()
+    await drain('high', 8_000)
+  } finally {
+    globalThis.fetch = realFetch
+  }
+
+  assert.deepEqual(sent[0]?.thinking, { type: 'enabled', budget_tokens: 24_576 })
+  assert.equal(sent[0]?.max_tokens, 32_000, 'дефолт модели уже больше бюджета — оставляем его')
+  assert.equal(sent[1]?.thinking, undefined, 'без effort блок thinking не отправляется')
+  assert.equal(sent[1]?.max_tokens, 32_000)
+  assert.equal(sent[2]?.max_tokens, 28_672, 'тесный max_tokens поднимается выше бюджета размышления')
+})


### PR DESCRIPTION
The `claude` route is the only one of the three without an effort selector, and its built-in catalog stops at 4.5. Both are fixable and I verified the assumption behind the first one against the live endpoint.

## Extended thinking works on the subscription endpoint

`resolveModel` carried this note:

> No reasoning metadata: the subscription endpoint's thinking support is not exercised, so effort requests reject as unsupported.

It is supported. With exactly the beta flags this provider already sends (`claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27`) and the Claude Code identity headers, a request with `thinking: {"type": "enabled", "budget_tokens": 4096}` returns HTTP 200 and streams `thinking` / `thinking_delta` / `signature_delta` blocks before the text. Checked on a Max subscription today, against `claude-opus-4-5` and the 5-series.

So the route now advertises `low`/`medium`/`high` (default `medium`) and translates the effort into a thinking budget on the wire — the Anthropic API has no `effort` field, it has a token budget. `max_tokens` covers the thinking budget too, so it is lifted above `budget + 4096` when the configured ceiling is tighter; otherwise the configured value stands.

## 5-series in the default catalog

`claude-opus-5`, `claude-sonnet-5` and `claude-fable-5` all answer 200 on the subscription endpoint. Unlike codex and grok, the claude route has no models endpoint to discover from, so `DEFAULT_MODELS.claude` is what users see until they override it in config — worth keeping current. The 4.5 entries stay where they are.

## Tests

Four assertions added to `test/models.spec.ts`: the effort metadata, the thinking block on the wire, absence of the block when no effort is set, and the `max_tokens` lift. Full suite: 75/75.

Note on running the suite locally: `devDependencies` point at `link:/Users/v1ki/...` paths, so a fresh clone cannot install them. I ran the tests against the published `@deepseek-ai/*` packages from a dsh profile. Might be worth switching those links to versioned deps so outside contributors can run `pnpm test` — happy to send that separately if useful.