### PR TITLE
fix(claude): defer detectClaudeVersion() until the Claude route is used

### DIFF
--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -63,7 +63,17 @@ export function detectClaudeVersion(): string {
   return CLAUDE_CLI_FALLBACK_VERSION
 }
 
-const CLAUDE_CLI_USER_AGENT = `claude-cli/${detectClaudeVersion()} (external, cli)`
+// Lazy + memoized: detectClaudeVersion() shells out to `claude --version`,
+// so this must not run at module-evaluation time (it would fire for every
+// consumer of this module regardless of whether Claude is a configured
+// provider). Computed on first use of getClaudeCliUserAgent() instead.
+let claudeCliUserAgent: string | undefined
+function getClaudeCliUserAgent(): string {
+  if (claudeCliUserAgent === undefined) {
+    claudeCliUserAgent = `claude-cli/${detectClaudeVersion()} (external, cli)`
+  }
+  return claudeCliUserAgent
+}
 export const CLAUDE_BETA_FALLBACK = [
   'claude-code-20250219',
   'oauth-2025-04-20',
@@ -291,7 +301,7 @@ export async function fetchClaudeUsage(
       'anthropic-beta': 'oauth-2025-04-20',
       // Unrecognized clients are aggressively rate-limited on this endpoint,
       // so it presents as the CLI like every other subscription request.
-      'user-agent': CLAUDE_CLI_USER_AGENT,
+      'user-agent': getClaudeCliUserAgent(),
       'accept': 'application/json',
     },
     ...signal === undefined ? {} : { signal },
@@ -358,7 +368,7 @@ export async function fetchClaudeModels(
     headers: {
       'authorization': `Bearer ${session.accessToken}`,
       'anthropic-version': '2023-06-01',
-      'user-agent': CLAUDE_CLI_USER_AGENT,
+      'user-agent': getClaudeCliUserAgent(),
       'anthropic-dangerous-direct-browser-access': 'true',
       'accept': 'application/json',
     },
@@ -568,7 +578,7 @@ export class ClaudeAdapter extends LlmAdapter {
         'authorization': `Bearer ${session.accessToken}`,
         'anthropic-version': '2023-06-01',
         'anthropic-beta': CLAUDE_BETA_FLAGS,
-        'user-agent': CLAUDE_CLI_USER_AGENT,
+        'user-agent': getClaudeCliUserAgent(),
         'x-app': 'cli',
         'anthropic-dangerous-direct-browser-access': 'true',
         'accept': 'text/event-stream',


### PR DESCRIPTION
## Problem

`src/providers/claude.ts` computes the Claude user-agent at **module top level**:

```ts
const CLAUDE_CLI_USER_AGENT = `claude-cli/${detectClaudeVersion()} (external, cli)`
```

`detectClaudeVersion()` shells out synchronously (`execFileSync('claude', ['--version'], { timeout: 3000 })`), and `src/index.ts` imports all three provider modules unconditionally. So the spawn happens the moment the host imports the plugin entry — **before `apply()` reads `config.providers`**.

Consequences:

- A user who configures a subset, e.g. `providers: [grok]`, still pays a synchronous `claude --version` spawn on every mount, for a CLI this plugin was not asked to touch.
- On machines without the `claude` CLI it is a guaranteed failed spawn on every boot (swallowed by `catch {}`), and a hanging `claude` shim can stall startup up to the 3s timeout.
- For anyone auditing what a headless/automation profile touches, "mounting this plugin invokes a third-party CLI regardless of provider selection or login state" is surprising.

## Fix

Make the user-agent lazy + memoized (`getClaudeCliUserAgent()`), called at the three sites that actually talk to Anthropic endpoints (`fetchClaudeUsage`, `fetchClaudeModels`, `ClaudeAdapter.stream`). Same value, same behavior on the Claude path — it is just no longer computed at import time.

One file, +14/−4, no formatting or behavior changes elsewhere. (`readClaudeCodeCredentials()` is already correctly gated behind the `/subscriptions-auth` RPC channel, so it needed no change.)

## Verification

Tested against `0.1.0-rc.7` with a profile mounting this plugin as `providers: [grok]` only:

- **Probe**: a PATH-shadowed fake `claude` binary that logs every invocation. Unpatched build → logged `claude invoked: --version` on boot. Patched build → **zero invocations** across repeated headless and web boots. Probe validity confirmed by a positive control.
- **Provider scoping**: `ctx.llm.listProviders()` at runtime returns only the configured route (plus the harness default), confirming `providers: [grok]` still works end to end.
- **Claude path unaffected**: after OAuth login, Grok requests serve normally; the Claude user-agent value is unchanged when that path is exercised.

Thanks for the plugin — the `providers` subset design is exactly what I needed; this just makes the subset fully inert for the routes it excludes.
