### PR TITLE
fix(claude): keep replayed tool calls and tool_result ordering valid on the wire

### DIFF
--- a/src/translate/anthropic.ts
+++ b/src/translate/anthropic.ts
@@ -76,12 +76,20 @@ export function toAnthropicMessages(messages: readonly TranslatableMessage[]): A
           blocks.push({ type: 'text', text: block.text })
           break
         case 'tool-call':
-          blocks.push({
-            type: 'tool_use',
-            id: String(block.id),
-            name: block.name,
-            input: parseToolInput(block.arguments),
-          })
+          // Anthropic accepts `tool_use` only in assistant messages, and only
+          // when a matching `tool_result` follows. A tool call in any other
+          // role is replayed narrative — a settled subagent's closing message
+          // spliced into the parent as a user-role notice carries the calls it
+          // died holding, which no result will ever answer — so it rides as
+          // descriptive text instead of a call the API would reject.
+          blocks.push(role === 'assistant'
+            ? {
+                type: 'tool_use',
+                id: String(block.id),
+                name: block.name,
+                input: parseToolInput(block.arguments),
+              }
+            : { type: 'text', text: `[tool call ${block.name}: ${block.arguments}]` })
           break
         case 'tool-result':
           blocks.push({

--- a/src/translate/anthropic.ts
+++ b/src/translate/anthropic.ts
@@ -54,11 +54,35 @@ function parseToolInput(raw: string): Record<string, unknown> {
 }
 
 /**
+ * Move a user message's `tool_result` blocks into one contiguous run at the
+ * front, preserving the relative order of both groups.
+ *
+ * Anthropic answers every `tool_use` against the blocks that *lead* the next
+ * message, so a block of any other kind before or between the results reads
+ * as a call left unanswered and the request is rejected. The harness merges
+ * everything queued for one user turn into a single message, and a parallel
+ * tool batch arrives as one result message per call, so any context spliced
+ * mid-batch lands between two results. Restoring the run here keeps that
+ * independent of delivery order. Order *among* the results does not matter.
+ * @param message - one assembled user message, reordered in place.
+ */
+function leadWithToolResults(message: AnthropicMessage): void {
+  const firstOther = message.content.findIndex(block => block.type !== 'tool_result')
+  if (firstOther === -1) return
+  if (!message.content.slice(firstOther).some(block => block.type === 'tool_result')) return
+  message.content = [
+    ...message.content.filter(block => block.type === 'tool_result'),
+    ...message.content.filter(block => block.type !== 'tool_result'),
+  ]
+}
+
+/**
  * Convert harness messages into Anthropic messages. Consecutive same-role
  * messages merge into one message with multiple content blocks; tool results
- * arrive as user messages with `tool_result` blocks; system-role messages are
- * handled by {@link toAnthropicSystem} and skipped here. Reasoning blocks are
- * not replayed (v1). Images must arrive pre-resolved
+ * arrive as user messages with `tool_result` blocks, which a merged user
+ * message keeps in one leading run ({@link leadWithToolResults}); system-role
+ * messages are handled by {@link toAnthropicSystem} and skipped here.
+ * Reasoning blocks are not replayed (v1). Images must arrive pre-resolved
  * ({@link TranslatableMessage}); an unresolved ImageBlock is skipped because
  * its bytes are unreachable here.
  * @param messages - ordered conversation messages with resolved images.
@@ -118,6 +142,9 @@ export function toAnthropicMessages(messages: readonly TranslatableMessage[]): A
     const last = out[out.length - 1]
     if (last !== undefined && last.role === role) last.content.push(...blocks)
     else out.push({ role, content: blocks })
+  }
+  for (const message of out) {
+    if (message.role === 'user') leadWithToolResults(message)
   }
   return out
 }

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -235,11 +235,13 @@ test('toAnthropicMessages: merge, tool_use input parsing, tool_result', () => {
   ])
   assert.deepEqual(messages, [
     {
+      // The merged user message leads with its tool result; the texts keep
+      // their relative order behind it.
       role: 'user',
       content: [
+        { type: 'tool_result', tool_use_id: 'call-1', content: 'result text', is_error: true },
         { type: 'text', text: 'first' },
         { type: 'text', text: 'second' },
-        { type: 'tool_result', tool_use_id: 'call-1', content: 'result text', is_error: true },
       ],
     },
     {
@@ -277,6 +279,33 @@ test('toAnthropicMessages: a replayed tool call in a user message rides as text'
     ],
   }])
   assert.ok(!JSON.stringify(messages).includes('tool_use'))
+})
+
+test('toAnthropicMessages: merged user message keeps tool_result blocks in one leading run', () => {
+  // A parallel tool batch arrives as one result message per call, so context
+  // spliced mid-batch merges in between them. Anthropic answers each tool_use
+  // against the blocks leading the next message, so the results must regroup
+  // at the front or the request is rejected for an unanswered call.
+  const messages = toAnthropicMessages([
+    message('assistant', [toolCall('call-1', 'bash', '{}'), toolCall('call-2', 'bash', '{}')]),
+    message('user', [toolResult('call-1', 'first')], { kind: 'tool', callId: CallId('call-1') }),
+    message('user', [{ type: 'text', text: 'spliced notice' }]),
+    message('user', [toolResult('call-2', 'second')], { kind: 'tool', callId: CallId('call-2') }),
+  ])
+  assert.deepEqual(messages[1], {
+    role: 'user',
+    content: [
+      { type: 'tool_result', tool_use_id: 'call-1', content: 'first' },
+      { type: 'tool_result', tool_use_id: 'call-2', content: 'second' },
+      { type: 'text', text: 'spliced notice' },
+    ],
+  })
+
+  // A user message with no tool results is left exactly as assembled.
+  const plain = toAnthropicMessages([
+    message('user', [{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }]),
+  ])
+  assert.deepEqual(plain[0].content, [{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }])
 })
 
 test('toAnthropicMessages: resolved image parts become base64 image blocks', () => {

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -258,6 +258,27 @@ test('toAnthropicMessages: merge, tool_use input parsing, tool_result', () => {
   assert.deepEqual(malformed[0].content[0], { type: 'tool_use', id: 'c', name: 'n', input: {} })
 })
 
+test('toAnthropicMessages: a replayed tool call in a user message rides as text', () => {
+  // A settled background subagent's closing message is spliced into the parent
+  // conversation as a user-role notice, carrying the subagent's own blocks —
+  // including tool calls that never got a result. Anthropic rejects `tool_use`
+  // outside assistant messages, so those must not reach the wire as tool_use.
+  const messages = toAnthropicMessages([
+    message('user', [
+      { type: 'text', text: 'Background subagent 7f21c45a failed before it finished.' },
+      toolCall('toolu_01MG', 'bash', '{"command":"ls"}'),
+    ], { kind: 'user' }),
+  ])
+  assert.deepEqual(messages, [{
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Background subagent 7f21c45a failed before it finished.' },
+      { type: 'text', text: '[tool call bash: {"command":"ls"}]' },
+    ],
+  }])
+  assert.ok(!JSON.stringify(messages).includes('tool_use'))
+})
+
 test('toAnthropicMessages: resolved image parts become base64 image blocks', () => {
   const messages = toAnthropicMessages([{
     role: 'user',


### PR DESCRIPTION
Fixes #22.

## The defect

When a background subagent settles, DSH splices its closing assistant message into the parent conversation as a **`user`-role notice** (`source.kind: "subagent-settled"`, `form: "notice"`), carrying that message's blocks verbatim — including the `tool-call` blocks it was holding when it died.

`toAnthropicMessages()` mapped blocks to wire form by block type alone, never consulting `message.role`, so those replayed calls reached the wire as `tool_use` blocks inside a `user` message:

```
claude API error (HTTP 400): messages.52: `tool_use` blocks can only be in `assistant` messages
```

The failure is sticky — the notice stays in history, so every later turn in that session fails identically and the session has to be abandoned. `codex` and `grok` are unaffected because the Responses API models a call as a top-level `function_call` input item rather than a block inside a role-tagged message.

## The change

Branch on the message role before emitting `tool_use`. A tool call outside an assistant message is replayed narrative, and — because the subagent died mid-flight — its ids have no matching `tool_result`, so re-roling it to `assistant` would only trade one rejection for another. It rides as descriptive text instead, which keeps what the notice is *for* (what the subagent was doing when it died) rather than dropping the blocks:

```
[tool call bash: {"command": "grep -rn \"UI hint\" --include=*.md ."}]
```

## Verification

**Real session replay.** Session `acede550-…` is the reported failure. Replaying its 72 harness messages produces 53 Anthropic messages, and index **52** is the notice — matching the `messages.52` the API named. Before: `tool_result, text, text, tool_use, tool_use, text`. After: `tool_result, text, text, text, text, text`.

**Full structural sweep.** All 20 sessions on disk (537 Anthropic messages) checked against the contract — role/block agreement, `tool_use` ↔ `tool_result` pairing and adjacency, `tool_result` leading its user message, non-empty content, alternating roles, first-message-is-user:

| | clean | violations |
|---|---|---|
| before | 19/20 | `messages.52: tool_use-outside-assistant` ×2, `messages.52: dangling-tool_use-at-end` |
| after | 20/20 | none |

The `dangling-tool_use-at-end` line is the independent confirmation that re-roling was not an option.

**Live API.** A minimal synthetic request through the plugin's own headers, differing only in how the notice renders its tool call: `tool_use` → **HTTP 400** with the byte-identical message; `text` → **HTTP 200**.

**Built artifact.** The same sweep run against `lib/translate/anthropic.js` after `pnpm build` is also 20/20 clean, so the fix reaches the published bundle.

**Suite.** `pnpm test` — 115 tests, 109 pass, 0 fail, 6 skipped. Includes a regression test per commit, each written before its fix and observed failing on the exact wire defect.

## Second commit: `tool_result` blocks must lead a merged user message

The same merge has an ordering hazard, and probing the API pinned down the actual rule — a **contiguous leading run**, with order *among* the results free:

| user message | result |
|---|---|
| `[tool_result, text]` | 200 |
| `[text, tool_result]` | **400** |
| `[tool_result, text, tool_result]` | **400** |
| `[text, tool_result, tool_result]` | **400** |
| `[tool_result_B, tool_result_A]` (reversed) | 200 |

The 400 is not an ordering complaint — it surfaces as ``messages.N: `tool_use` ids were found without `tool_result` blocks immediately after``, because Anthropic answers each call against the blocks that *lead* the next message.

This is reachable rather than theoretical: a parallel tool batch arrives as one result message per call, and `toAnthropicMessages()` merges consecutive same-role messages in delivery order, so any context spliced mid-batch — a runtime-context snapshot, a settled-subagent notice — lands between two results and takes the request down.

`leadWithToolResults()` regroups the results at the front of each merged user message, preserving relative order within both groups. End-to-end through the built code, the two arms differing only in block order:

| merged user message | result |
|---|---|
| `tool_result, tool_result, text` (built output) | **200** |
| `tool_result, text, tool_result` (guard undone) | **400** |

The existing merge test encoded the old delivery order, which is a shape the API rejects whenever the result answers a call