### PR TITLE
feat(claude): cache the prompt prefix and the conversation tail

### DIFF
--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -18,6 +18,7 @@ import type { ClaudeSession } from '../auth/store.js'
 import type { AttachmentStore } from '@deepseek-ai/dsh-attachment'
 import { resolveImages } from '../translate/resolved.js'
 import {
+  markMessageCache,
   streamAnthropic,
   toAnthropicMessages,
   toAnthropicSystem,
@@ -559,11 +560,16 @@ export class ClaudeAdapter extends LlmAdapter {
     const effort = options.reasoningEffort !== undefined && disc?.reasoning !== undefined
       ? { output_config: { effort: String(options.reasoningEffort) } }
       : {}
+    // Assembled before the body so the breakpoints land on the blocks the
+    // body ships. Every marker costs one of Anthropic's four slots: three
+    // ride the history here, the fourth is on the last `system` block.
+    const anthropicMessages = toAnthropicMessages(messages)
+    markMessageCache(anthropicMessages)
     const body = {
       model: options.model,
       max_tokens: maxTokens,
       system: toAnthropicSystem(options.system, messages),
-      messages: toAnthropicMessages(messages),
+      messages: anthropicMessages,
       ...options.tools !== undefined && options.tools.length > 0
         ? { tools: toAnthropicTools(options.tools) }
         : {},

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -17,6 +17,7 @@ import type { FlowSpec } from '../auth/oauth-flow.js'
 import type { ClaudeSession } from '../auth/store.js'
 import type { AttachmentStore } from '@deepseek-ai/dsh-attachment'
 import { resolveImages } from '../translate/resolved.js'
+import type { TranslatableMessage } from '../translate/resolved.js'
 import {
   markMessageCache,
   streamAnthropic,
@@ -428,6 +429,45 @@ const CLAUDE_RETRY_JITTER_RATIO = 0.2
 /** The Claude 4.5 family accepts image input. */
 const CLAUDE_MODALITIES: readonly ('text' | 'image')[] = ['text', 'image']
 
+/**
+ * Assemble the Anthropic request body.
+ *
+ * Extracted from the adapter so the wire shape — cache breakpoints above all —
+ * is testable without a network round trip. The message array is marked before
+ * it is placed so the breakpoints land on the blocks the body ships: one on the
+ * last `system` block (covering `tools` + `system`, which render ahead of it)
+ * and up to three across the history, Anthropic's four-slot maximum.
+ * @param options - the generate request.
+ * @param messages - conversation messages with images already resolved.
+ * @param maxTokens - the resolved output cap.
+ * @param thinking - the thinking parameter, when the model takes one.
+ * @param effort - the reasoning effort, when the model advertises efforts.
+ * @returns the JSON body to POST.
+ */
+export function claudeRequestBody(
+  options: GenerateOptions,
+  messages: readonly TranslatableMessage[],
+  maxTokens: number,
+  thinking?: Record<string, unknown>,
+  effort?: string,
+): Record<string, unknown> {
+  const anthropicMessages = toAnthropicMessages(messages)
+  markMessageCache(anthropicMessages)
+  return {
+    model: options.model,
+    max_tokens: maxTokens,
+    system: toAnthropicSystem(options.system, messages),
+    messages: anthropicMessages,
+    ...options.tools !== undefined && options.tools.length > 0
+      ? { tools: toAnthropicTools(options.tools) }
+      : {},
+    ...thinking === undefined ? {} : { thinking },
+    ...effort === undefined ? {} : { output_config: { effort } },
+    stream: true,
+    ...options.sessionId !== undefined ? { metadata: { user_id: String(options.sessionId) } } : {},
+  }
+}
+
 /** Claude wire adapter: one instance serves the `claude` provider route. */
 export class ClaudeAdapter extends LlmAdapter {
   private readonly catalog: ModelCatalogCache
@@ -558,26 +598,9 @@ export class ClaudeAdapter extends LlmAdapter {
     const disc = await this.discovered(options.model)
     const thinking = this.thinkingParam(disc?.thinkingType, maxTokens)
     const effort = options.reasoningEffort !== undefined && disc?.reasoning !== undefined
-      ? { output_config: { effort: String(options.reasoningEffort) } }
-      : {}
-    // Assembled before the body so the breakpoints land on the blocks the
-    // body ships. Every marker costs one of Anthropic's four slots: three
-    // ride the history here, the fourth is on the last `system` block.
-    const anthropicMessages = toAnthropicMessages(messages)
-    markMessageCache(anthropicMessages)
-    const body = {
-      model: options.model,
-      max_tokens: maxTokens,
-      system: toAnthropicSystem(options.system, messages),
-      messages: anthropicMessages,
-      ...options.tools !== undefined && options.tools.length > 0
-        ? { tools: toAnthropicTools(options.tools) }
-        : {},
-      ...thinking === undefined ? {} : { thinking },
-      ...effort,
-      stream: true,
-      ...options.sessionId !== undefined ? { metadata: { user_id: String(options.sessionId) } } : {},
-    }
+      ? String(options.reasoningEffort)
+      : undefined
+    const body = claudeRequestBody(options, messages, maxTokens, thinking, effort)
     return fetch(CLAUDE_API_URL, {
       method: 'POST',
       headers: {

--- a/src/translate/anthropic.ts
+++ b/src/translate/anthropic.ts
@@ -169,16 +169,24 @@ export function toAnthropicSystem(system?: string, messages?: readonly Translata
 }
 
 /**
- * Map harness tool schemas to Anthropic tools.
+ * Map harness tool schemas to Anthropic tools, in name order.
+ *
+ * `tools` renders at position 0 of the cached prefix, so any reordering
+ * invalidates every cache entry behind it — `system` and the whole
+ * conversation included. Registration order belongs to the caller and plugin
+ * load order can differ between processes, so the wire order is fixed here
+ * instead. Anthropic selects a tool by name; the array order carries nothing.
  * @param tools - tool schemas from the request.
- * @returns Anthropic `tools` array entries.
+ * @returns Anthropic `tools` array entries, ordered by tool name.
  */
 export function toAnthropicTools(tools: readonly ToolSchema[]): Record<string, unknown>[] {
-  return tools.map(tool => ({
-    name: tool.name,
-    description: tool.description,
-    input_schema: tool.parameters,
-  }))
+  return [...tools]
+    .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0))
+    .map(tool => ({
+      name: tool.name,
+      description: tool.description,
+      input_schema: tool.parameters,
+    }))
 }
 
 /** The subset of Anthropic SSE event shapes this translator reads. */

--- a/src/translate/anthropic.ts
+++ b/src/translate/anthropic.ts
@@ -32,6 +32,24 @@ export const CLAUDE_CODE_IDENTITY = 'You are Claude Code, Anthropic\'s official 
 export const SYSTEM_REMINDER_OPEN = '<system-reminder>'
 export const SYSTEM_REMINDER_CLOSE = '</system-reminder>'
 
+/**
+ * How far apart consecutive message breakpoints sit, in content blocks.
+ *
+ * A breakpoint looks back at most 20 blocks for an entry an earlier request
+ * wrote, so marks must stay closer than that: one agentic turn can append a
+ * dozen tool_use/tool_result blocks at once, and a single trailing mark would
+ * silently fall out of range and rebuild the whole prefix.
+ */
+export const CACHE_BLOCK_STRIDE = 15
+
+/**
+ * Message breakpoints per request. Anthropic allows four in total and the
+ * last `system` block takes the fourth, so three are left for the history —
+ * enough to tolerate a turn appending roughly {@link CACHE_BLOCK_STRIDE} × 3
+ * blocks before a read is lost.
+ */
+export const MESSAGE_CACHE_BREAKPOINTS = 3
+
 /** One Anthropic request message. */
 export interface AnthropicMessage {
   role: 'user' | 'assistant'
@@ -182,6 +200,26 @@ export function toAnthropicMessages(messages: readonly TranslatableMessage[]): A
 }
 
 /**
+ * Mark the conversation's cache breakpoints in place: the last content block,
+ * then one every {@link CACHE_BLOCK_STRIDE} blocks backwards, {@link
+ * MESSAGE_CACHE_BREAKPOINTS} in total.
+ *
+ * The history is append-only, so the block one request marks last is
+ * byte-identical in the next — that entry is what the next request reads.
+ * Marks are counted across the flattened block sequence, not per message,
+ * because the lookback window Anthropic walks counts blocks the same way.
+ * @param messages - assembled Anthropic messages, marked in place.
+ */
+export function markMessageCache(messages: readonly AnthropicMessage[]): void {
+  const blocks = messages.flatMap(message => message.content)
+  for (let mark = 0; mark < MESSAGE_CACHE_BREAKPOINTS; mark++) {
+    const at = blocks.length - 1 - mark * CACHE_BLOCK_STRIDE
+    if (at < 0) return
+    blocks[at].cache_control = { type: 'ephemeral' }
+  }
+}
+
+/**
  * Build the Anthropic `system` array: the mandatory Claude Code identity
  * block, then the explicit system prompt, then any system-role messages.
  * @param system - explicit system prompt, when set.
@@ -198,6 +236,10 @@ export function toAnthropicSystem(system?: string, messages?: readonly Translata
       if (block.type === 'text') blocks.push({ type: 'text', text: block.text })
     }
   }
+  // `tools` renders ahead of `system`, so this one marker caches both. It is
+  // deliberately separate from the message marks: a tool_choice or thinking
+  // change invalidates the messages tier only, and this entry survives it.
+  blocks[blocks.length - 1].cache_control = { type: 'ephemeral' }
   return blocks
 }
 

--- a/src/translate/anthropic.ts
+++ b/src/translate/anthropic.ts
@@ -28,6 +28,10 @@ import type { TranslatableMessage } from './resolved.js'
  */
 export const CLAUDE_CODE_IDENTITY = 'You are Claude Code, Anthropic\'s official CLI for Claude.'
 
+/** Tags wrapping a mid-conversation system message where it sits in the history. */
+export const SYSTEM_REMINDER_OPEN = '<system-reminder>'
+export const SYSTEM_REMINDER_CLOSE = '</system-reminder>'
+
 /** One Anthropic request message. */
 export interface AnthropicMessage {
   role: 'user' | 'assistant'
@@ -77,11 +81,30 @@ function leadWithToolResults(message: AnthropicMessage): void {
 }
 
 /**
+ * Index of the first non-system message; `messages.length` when every message
+ * is a system one.
+ *
+ * A system message before the conversation starts is the operator's opening
+ * instruction and belongs in the `system` slot. One that arrives later is
+ * mid-conversation context, and hoisting it into `system` would move bytes in
+ * front of the whole history — invalidating every cached turn behind it — so
+ * it stays where it is, as a reminder block in `messages`.
+ * @param messages - ordered conversation messages.
+ * @returns the boundary index separating the two.
+ */
+function conversationStart(messages: readonly TranslatableMessage[]): number {
+  const index = messages.findIndex(message => message.role !== 'system')
+  return index === -1 ? messages.length : index
+}
+
+/**
  * Convert harness messages into Anthropic messages. Consecutive same-role
  * messages merge into one message with multiple content blocks; tool results
  * arrive as user messages with `tool_result` blocks, which a merged user
  * message keeps in one leading run ({@link leadWithToolResults}); system-role
- * messages are handled by {@link toAnthropicSystem} and skipped here.
+ * messages before the conversation starts are handled by
+ * {@link toAnthropicSystem} and skipped here, while a later one rides in
+ * place as a user-role `<system-reminder>` block.
  * Reasoning blocks are not replayed (v1). Images must arrive pre-resolved
  * ({@link TranslatableMessage}); an unresolved ImageBlock is skipped because
  * its bytes are unreachable here.
@@ -90,14 +113,23 @@ function leadWithToolResults(message: AnthropicMessage): void {
  */
 export function toAnthropicMessages(messages: readonly TranslatableMessage[]): AnthropicMessage[] {
   const out: AnthropicMessage[] = []
-  for (const message of messages) {
-    if (message.role === 'system') continue
-    const role = message.role
+  const start = conversationStart(messages)
+  for (const [index, message] of messages.entries()) {
+    // A leading system message is an opening instruction; toAnthropicSystem
+    // owns those. A later one rides here so the cached prefix ahead of it
+    // stays byte-identical.
+    if (message.role === 'system' && index < start) continue
+    const role = message.role === 'system' ? 'user' : message.role
     const blocks: Record<string, unknown>[] = []
     for (const block of message.content) {
       switch (block.type) {
         case 'text':
-          blocks.push({ type: 'text', text: block.text })
+          blocks.push({
+            type: 'text',
+            text: message.role === 'system'
+              ? `${SYSTEM_REMINDER_OPEN}${block.text}${SYSTEM_REMINDER_CLOSE}`
+              : block.text,
+          })
           break
         case 'tool-call':
           // Anthropic accepts `tool_use` only in assistant messages, and only
@@ -153,14 +185,15 @@ export function toAnthropicMessages(messages: readonly TranslatableMessage[]): A
  * Build the Anthropic `system` array: the mandatory Claude Code identity
  * block, then the explicit system prompt, then any system-role messages.
  * @param system - explicit system prompt, when set.
- * @param messages - conversation messages; their system-role text is appended.
+ * @param messages - conversation messages; the system-role text preceding the
+ * conversation is appended, and a later one is left to {@link toAnthropicMessages}.
  * @returns the system content blocks.
  */
 export function toAnthropicSystem(system?: string, messages?: readonly TranslatableMessage[]): Record<string, unknown>[] {
   const blocks: Record<string, unknown>[] = [{ type: 'text', text: CLAUDE_CODE_IDENTITY }]
   if (system !== undefined && system.length > 0) blocks.push({ type: 'text', text: system })
-  for (const message of messages ?? []) {
-    if (message.role !== 'system') continue
+  const history = messages ?? []
+  for (const message of history.slice(0, conversationStart(history))) {
     for (const block of message.content) {
       if (block.type === 'text') blocks.push({ type: 'text', text: block.text })
     }

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -7,10 +7,11 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import { MessageId, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import type { Message } from '@deepseek-ai/dsh-llm'
 import { CodexAdapter, codexRequestBody, fetchCodexModels } from '../src/providers/codex.js'
 import { GrokAdapter } from '../src/providers/grok.js'
-import { ClaudeAdapter } from '../src/providers/claude.js'
+import { ClaudeAdapter, claudeRequestBody } from '../src/providers/claude.js'
 import { ModelCatalogCache, TokenManager } from '../src/providers/common.js'
 import type { CatalogPersistence, CatalogSnapshot, FetchFn } from '../src/providers/common.js'
 import type { ClaudeSession, CodexSession, GrokSession } from '../src/auth/store.js'
@@ -273,48 +274,64 @@ test('codexRequestBody sends service_tier priority only on the fast tier', () =>
   assert.deepEqual(fast.reasoning, { effort: 'high', summary: 'auto' })
 })
 
-test('codexRequestBody bounds tool-call ids without losing their pairings', () => {
-  const short = 'call-short'
-  const sharedPrefix = `call_${'x'.repeat(60)}`
-  const longA = `${sharedPrefix}-a`
-  const longB = `${sharedPrefix}-b`
-  const resolved = {
-    input: [
-      { type: 'function_call', call_id: short, name: 'short', arguments: '{}' },
-      { type: 'function_call_output', call_id: short, output: 'short result' },
-      { type: 'function_call', call_id: longA, name: 'long_a', arguments: '{}' },
-      { type: 'function_call_output', call_id: longA, output: 'long A result' },
-      { type: 'function_call', call_id: longB, name: 'long_b', arguments: '{}' },
-      { type: 'function_call_output', call_id: longB, output: 'long B result' },
-    ],
+/** One text-only message of any role, for request-body assembly. */
+function claudeMessage(id: string, role: Message['role'], text: string): Message {
+  return {
+    id: MessageId(id),
+    role,
+    content: [{ type: 'text', text }],
+    source: role === 'assistant'
+      ? { kind: 'model', provider: 'claude', model: 'claude-opus-5' }
+      : { kind: 'user' },
   }
-  const options = { provider: 'codex', model: 'gpt-5.1-codex', messages: [] }
-  const first = codexRequestBody(options, resolved, false)
-  const second = codexRequestBody(options, resolved, false)
-  const ids = (first.input as Record<string, unknown>[]).map(item => String(item.call_id))
+}
 
-  assert.equal(ids[0], short)
-  assert.equal(ids[1], short)
-  assert.ok(ids.every(id => id.length <= 64))
-  assert.equal(ids[2], ids[3])
-  assert.equal(ids[4], ids[5])
-  assert.notEqual(ids[2], ids[4])
-  assert.deepEqual(second.input, first.input)
+test('claudeRequestBody ships the cache breakpoints and never exceeds four', () => {
+  const history: Message[] = [claudeMessage('s0', 'system', 'opening')]
+  for (let turn = 0; turn < 16; turn++) {
+    history.push(claudeMessage(`u${turn}`, 'user', `q${turn}`))
+    history.push(claudeMessage(`a${turn}`, 'assistant', `r${turn}`))
+  }
+  const body = claudeRequestBody(
+    {
+      provider: 'claude',
+      model: 'claude-opus-5',
+      messages: history,
+      system: 'explicit',
+      tools: [
+        { name: 'write', description: 'write a file', parameters: { type: 'object' } },
+        { name: 'bash', description: 'run', parameters: { type: 'object' } },
+      ],
+    },
+    history,
+    32_000,
+    { type: 'adaptive', display: 'summarized' },
+    'high',
+  )
+  const system = body.system as Record<string, unknown>[]
+  const messages = body.messages as { content: Record<string, unknown>[] }[]
+  const marked = [...system, ...messages.flatMap(entry => entry.content)]
+    .filter(block => block.cache_control !== undefined)
+  assert.equal(marked.length, 4, 'one on system plus three across the history is Anthropic\'s maximum')
+  assert.deepEqual(system[system.length - 1].cache_control, { type: 'ephemeral' }, 'the tools+system prefix is cached')
+  assert.deepEqual(
+    (body.tools as { name: string }[]).map(tool => tool.name),
+    ['bash', 'write'],
+    'tools ride in name order',
+  )
+  assert.deepEqual(body.thinking, { type: 'adaptive', display: 'summarized' })
+  assert.deepEqual(body.output_config, { effort: 'high' })
+  assert.equal(body.stream, true)
+})
 
-  // A short id that happens to equal the first hash candidate is reserved;
-  // the long id is rehashed rather than associating two calls with one id.
-  const reserved = ids[2]
-  const collision = codexRequestBody(options, {
-    input: [
-      { type: 'function_call', call_id: reserved, name: 'reserved', arguments: '{}' },
-      { type: 'function_call', call_id: longA, name: 'long_a', arguments: '{}' },
-      { type: 'function_call_output', call_id: longA, output: 'long A result' },
-    ],
-  }, false)
-  const collisionIds = (collision.input as Record<string, unknown>[]).map(item => String(item.call_id))
-  assert.equal(collisionIds[0], reserved)
-  assert.equal(collisionIds[1], collisionIds[2])
-  assert.notEqual(collisionIds[1], reserved)
+test('claudeRequestBody omits tools, thinking and effort when the request carries none', () => {
+  const history: Message[] = [claudeMessage('u0', 'user', 'hi')]
+  const body = claudeRequestBody({ provider: 'claude', model: 'claude-opus-5', messages: history }, history, 32_000)
+  assert.equal('tools' in body, false)
+  assert.equal('thinking' in body, false)
+  assert.equal('output_config' in body, false)
+  assert.equal('metadata' in body, false)
+  assert.equal(body.max_tokens, 32_000)
 })
 
 test('modalities: codex and claude declare image input; grok gates text-only models', async () => {

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -274,6 +274,48 @@ test('codexRequestBody sends service_tier priority only on the fast tier', () =>
   assert.deepEqual(fast.reasoning, { effort: 'high', summary: 'auto' })
 })
 
+test('codexRequestBody bounds tool-call ids without losing their pairings', () => {
+  const short = 'call-short'
+  const sharedPrefix = `call_${'x'.repeat(60)}`
+  const longA = `${sharedPrefix}-a`
+  const longB = `${sharedPrefix}-b`
+  const resolved = {
+    input: [
+      { type: 'function_call', call_id: short, name: 'short', arguments: '{}' },
+      { type: 'function_call_output', call_id: short, output: 'short result' },
+      { type: 'function_call', call_id: longA, name: 'long_a', arguments: '{}' },
+      { type: 'function_call_output', call_id: longA, output: 'long A result' },
+      { type: 'function_call', call_id: longB, name: 'long_b', arguments: '{}' },
+      { type: 'function_call_output', call_id: longB, output: 'long B result' },
+    ],
+  }
+  const options = { provider: 'codex', model: 'gpt-5.1-codex', messages: [] }
+  const first = codexRequestBody(options, resolved, false)
+  const second = codexRequestBody(options, resolved, false)
+  const ids = (first.input as Record<string, unknown>[]).map(item => String(item.call_id))
+
+  assert.equal(ids[0], short)
+  assert.equal(ids[1], short)
+  assert.ok(ids.every(id => id.length <= 64))
+  assert.equal(ids[2], ids[3])
+  assert.equal(ids[4], ids[5])
+  assert.notEqual(ids[2], ids[4])
+  assert.deepEqual(second.input, first.input)
+
+  const reserved = ids[2]
+  const collision = codexRequestBody(options, {
+    input: [
+      { type: 'function_call', call_id: reserved, name: 'reserved', arguments: '{}' },
+      { type: 'function_call', call_id: longA, name: 'long_a', arguments: '{}' },
+      { type: 'function_call_output', call_id: longA, output: 'long A result' },
+    ],
+  }, false)
+  const collisionIds = (collision.input as Record<string, unknown>[]).map(item => String(item.call_id))
+  assert.equal(collisionIds[0], reserved)
+  assert.equal(collisionIds[1], collisionIds[2])
+  assert.notEqual(collisionIds[1], reserved)
+})
+
 /** One text-only message of any role, for request-body assembly. */
 function claudeMessage(id: string, role: Message['role'], text: string): Message {
   return {

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -334,6 +334,33 @@ test('toAnthropicSystem: Claude Code identity first, then explicit and history s
   assert.equal(toAnthropicSystem().length, 1, 'the identity block is always present')
 })
 
+test('toAnthropicSystem hoists only the system messages that precede the conversation', () => {
+  const history = [
+    message('system', [{ type: 'text', text: 'opening' }]),
+    message('user', [{ type: 'text', text: 'hi' }]),
+    message('system', [{ type: 'text', text: 'mid-conversation' }]),
+  ]
+  assert.deepEqual(toAnthropicSystem('explicit', history), [
+    { type: 'text', text: CLAUDE_CODE_IDENTITY },
+    { type: 'text', text: 'explicit' },
+    { type: 'text', text: 'opening' },
+  ], 'a later system message must not move in front of the cached history')
+})
+
+test('toAnthropicMessages: a mid-conversation system message rides in place as a reminder', () => {
+  const messages = toAnthropicMessages([
+    message('system', [{ type: 'text', text: 'opening' }]),
+    message('user', [{ type: 'text', text: 'hi' }]),
+    message('assistant', [{ type: 'text', text: 'hello' }]),
+    message('system', [{ type: 'text', text: 'terse mode' }]),
+  ])
+  assert.deepEqual(messages, [
+    { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    { role: 'user', content: [{ type: 'text', text: '<system-reminder>terse mode</system-reminder>' }] },
+  ])
+})
+
 test('toAnthropicTools maps to input_schema tools', () => {
   assert.deepEqual(toAnthropicTools([{ name: 'bash', description: 'run', parameters: { type: 'object' } }]), [
     { name: 'bash', description: 'run', input_schema: { type: 'object' } },

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -397,6 +397,48 @@ test('markMessageCache leaves an empty conversation alone', () => {
   assert.doesNotThrow(() => { markMessageCache([]) })
 })
 
+test('toAnthropicMessages: a system reminder merged with tool results stays behind the leading run', () => {
+  const messages = toAnthropicMessages([
+    message('user', [{ type: 'text', text: 'go' }]),
+    message('assistant', [toolCall('c1', 'bash', '{}')]),
+    message('user', [toolResult('c1', 'ok')]),
+    message('system', [{ type: 'text', text: 'terse mode' }]),
+  ])
+  assert.deepEqual(messages[2].content, [
+    { type: 'tool_result', tool_use_id: 'c1', content: 'ok' },
+    { type: 'text', text: '<system-reminder>terse mode</system-reminder>' },
+  ], 'tool_result blocks must still lead the merged message')
+})
+
+test('an all-system history hoists everything and leaves no messages', () => {
+  const history = [
+    message('system', [{ type: 'text', text: 'first' }]),
+    message('system', [{ type: 'text', text: 'second' }]),
+  ]
+  assert.deepEqual(toAnthropicSystem(undefined, history), [
+    { type: 'text', text: CLAUDE_CODE_IDENTITY },
+    { type: 'text', text: 'first' },
+    { type: 'text', text: 'second', cache_control: { type: 'ephemeral' } },
+  ])
+  assert.deepEqual(toAnthropicMessages(history), [])
+})
+
+test('toAnthropicSystem marks the identity block when it is the only one', () => {
+  assert.deepEqual(toAnthropicSystem(), [
+    { type: 'text', text: CLAUDE_CODE_IDENTITY, cache_control: { type: 'ephemeral' } },
+  ])
+})
+
+test('markMessageCache marks a tool_result block when the turn ends on one', () => {
+  const content: Record<string, unknown>[] = [
+    { type: 'tool_result', tool_use_id: 'c1', content: 'ok' },
+    { type: 'tool_result', tool_use_id: 'c2', content: 'ok' },
+  ]
+  markMessageCache([{ role: 'user', content }])
+  assert.equal(content[0].cache_control, undefined)
+  assert.deepEqual(content[1].cache_control, { type: 'ephemeral' })
+})
+
 test('toAnthropicTools maps to input_schema tools', () => {
   assert.deepEqual(toAnthropicTools([{ name: 'bash', description: 'run', parameters: { type: 'object' } }]), [
     { name: 'bash', description: 'run', input_schema: { type: 'object' } },

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -340,6 +340,22 @@ test('toAnthropicTools maps to input_schema tools', () => {
   ])
 })
 
+test('toAnthropicTools sorts by name so the tools prefix survives registration order', () => {
+  const schemas = [
+    { name: 'write', description: 'write a file', parameters: { type: 'object' } },
+    { name: 'bash', description: 'run', parameters: { type: 'object' } },
+  ]
+  assert.deepEqual(toAnthropicTools(schemas), [
+    { name: 'bash', description: 'run', input_schema: { type: 'object' } },
+    { name: 'write', description: 'write a file', input_schema: { type: 'object' } },
+  ])
+  assert.deepEqual(
+    toAnthropicTools([...schemas].reverse()),
+    toAnthropicTools(schemas),
+    'the wire order does not depend on the input order',
+  )
+})
+
 test('Anthropic translator: text + tool_use stream with usage before finish', () => {
   const events: AnthropicStreamEvent[] = [
     { type: 'message_start', message: { usage: { input_tokens: 50, cache_read_input_tokens: 10 } } },

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -17,11 +17,12 @@ import type { ResponsesStreamEvent } from '../src/translate/responses.js'
 import {
   AnthropicStreamTranslator,
   CLAUDE_CODE_IDENTITY,
+  markMessageCache,
   toAnthropicMessages,
   toAnthropicSystem,
   toAnthropicTools,
 } from '../src/translate/anthropic.js'
-import type { AnthropicStreamEvent } from '../src/translate/anthropic.js'
+import type { AnthropicMessage, AnthropicStreamEvent } from '../src/translate/anthropic.js'
 import { resolveImages } from '../src/translate/resolved.js'
 
 let messageCounter = 0
@@ -329,7 +330,7 @@ test('toAnthropicSystem: Claude Code identity first, then explicit and history s
   assert.deepEqual(blocks, [
     { type: 'text', text: CLAUDE_CODE_IDENTITY },
     { type: 'text', text: 'explicit' },
-    { type: 'text', text: 'from history' },
+    { type: 'text', text: 'from history', cache_control: { type: 'ephemeral' } },
   ])
   assert.equal(toAnthropicSystem().length, 1, 'the identity block is always present')
 })
@@ -343,7 +344,7 @@ test('toAnthropicSystem hoists only the system messages that precede the convers
   assert.deepEqual(toAnthropicSystem('explicit', history), [
     { type: 'text', text: CLAUDE_CODE_IDENTITY },
     { type: 'text', text: 'explicit' },
-    { type: 'text', text: 'opening' },
+    { type: 'text', text: 'opening', cache_control: { type: 'ephemeral' } },
   ], 'a later system message must not move in front of the cached history')
 })
 
@@ -359,6 +360,41 @@ test('toAnthropicMessages: a mid-conversation system message rides in place as a
     { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
     { role: 'user', content: [{ type: 'text', text: '<system-reminder>terse mode</system-reminder>' }] },
   ])
+})
+
+test('toAnthropicSystem marks its last block as the tools+system breakpoint', () => {
+  const blocks = toAnthropicSystem('explicit')
+  assert.deepEqual(blocks, [
+    { type: 'text', text: CLAUDE_CODE_IDENTITY },
+    { type: 'text', text: 'explicit', cache_control: { type: 'ephemeral' } },
+  ])
+})
+
+test('markMessageCache marks the tail and one block every stride backwards', () => {
+  const content: Record<string, unknown>[] = Array.from(
+    { length: 40 },
+    (_, index) => ({ type: 'text', text: `b${index}` }),
+  )
+  const messages: AnthropicMessage[] = [{ role: 'user', content }]
+  markMessageCache(messages)
+  const marked = content.flatMap((block, index) => ('cache_control' in block ? [index] : []))
+  assert.deepEqual(marked, [9, 24, 39], 'three marks, 15 blocks apart, anchored at the tail')
+})
+
+test('markMessageCache marks across messages and stops at the start of a short one', () => {
+  const first: Record<string, unknown>[] = [{ type: 'text', text: 'hi' }]
+  const second: Record<string, unknown>[] = [{ type: 'text', text: 'hello' }]
+  const messages: AnthropicMessage[] = [
+    { role: 'user', content: first },
+    { role: 'assistant', content: second },
+  ]
+  markMessageCache(messages)
+  assert.deepEqual(first, [{ type: 'text', text: 'hi' }], 'no mark within a stride of the tail')
+  assert.deepEqual(second, [{ type: 'text', text: 'hello', cache_control: { type: 'ephemeral' } }])
+})
+
+test('markMessageCache leaves an empty conversation alone', () => {
+  assert.doesNotThrow(() => { markMessageCache([]) })
 })
 
 test('toAnthropicTools maps to input_schema tools', () => {


### PR DESCRIPTION
Closes #24.

> **Stacked on #23.** This branch forks from `fix/replayed-tool-call-in-user-message`, so the first two commits here are that PR's — the base has to be a branch in this repo, and the parent lives in the fork. Review the last four commits; I will rebase once #23 lands.

The `claude` route sent no `cache_control` at all, so every agentic step reprocessed `tools`, `system` and the whole history at full weight — on a subscription that burns the compute window far faster than the CLI this route presents as. Two prefix-stability fixes land first, because a breakpoint over an unstable prefix is a cache write nobody reads.

### `fix(claude): order tools by name for a stable cache prefix`

`tools` renders at position 0 of the cached prefix, so any reordering invalidates everything behind it. Registration order belongs to the caller and plugin load order can differ between processes, so the wire order is fixed by name. Anthropic selects a tool by name; the array order carries nothing.

### `fix(claude): keep a mid-conversation system message in place`

`toAnthropicMessages` skipped every system-role message and `toAnthropicSystem` appended them all to the `system` array, so one produced at turn 20 landed ahead of the whole history and changed the prefix in front of every cached turn. Only the system messages preceding the conversation are hoisted now; a later one rides in `messages` at its own position, wrapped in `<system-reminder>` — the same shape Claude Code itself uses, and model-independent, unlike the typed `{"role": "system"}` form (Opus 5 / Opus 4.8 / Fable 5 only, 400 elsewhere).

### `feat(claude): cache the prompt prefix and the conversation tail`

Four breakpoints, the API maximum:

- **One on the last `system` block.** `tools` renders ahead of `system`, so one marker caches both. Keeping it separate from the message marks is what bounds the damage of an effort or thinking change: those invalidate the messages tier only, and this entry survives.
- **Three rolling marks across the history**, on the last content block and every 15 blocks backwards. A breakpoint looks back at most 20 content blocks for an entry an earlier request wrote; one agentic turn can append a dozen `tool_use`/`tool_result` blocks, so a lone tail marker silently falls out of range. Three marks at stride 15 keep consecutive write points inside the window and tolerate a turn appending ~45 blocks.

The history is append-only, so the block one request marks last is byte-identical in the next — that entry is what the next request reads.

Default 5-minute TTL only, and no new `anthropic-beta` flag. `ttl: "1h"` is deliberately out of scope: sources disagree on whether `extended-cache-ttl-2025-04-11` is still required, and a rejected beta flag would fail every request on this route. Reads refresh the 5-minute entry, so a working loop keeps it alive; only an idle gap longer than 5 minutes costs one re-write.

### `test(claude): cover the cache breakpoints on the assembled body`

`claudeRequestBody` is extracted the way `codexRequestBody` already is, so the wire shape the adapter ships — breakpoint count and placement above all — is asserted without a network round trip.

## Verification

`pnpm test`: 128 tests, 122 pass, 0 fail, 6 skipped (the skips predate this branch). Mutating the two placement lines kills 9 of the new tests.

Live check against the subscription endpoint, ~9.4k-token prefix on Haiku 4.5 — whose 4096-token minimum cacheable prefix is the strictest of any current model, so a hit there holds everywhere:

```
request 1 (cold): input=3  cache_write=9411  cache_read=0
request 2 (warm): input=3  cache_write=14    cache_read=9411
```

The second request read 9411 tokens from cache and wrote 14 — only the new turn. Before this branch both fields were zero and `input_tokens` was ~9400 on every request.

https://claude.ai/code/session_01Xw1EjAGy3Zz1jufzuqtEHm