### PR TITLE
feat: Copilot 接入 GPT-5.6 系列与思考等级,并修正双端点模型的请求路由

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Logged-in providers join the session model picker with their live model catalogs
 
 ![Model picker with subscription models](https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-picker.png)
 
-Models that advertise reasoning levels get an **Effort** selector in the same menu — Codex models, and Grok 4.6 / 4.5 (levels and defaults come from each provider's live catalog, not a hardcoded list):
+Models that advertise reasoning levels get an **Effort** selector in the same menu — Codex models, Grok 4.6 / 4.5, and Copilot's reasoning models (levels and defaults come from each provider's live catalog, not a hardcoded list; Copilot's `capabilities.supports.reasoning_effort` array is sent as `reasoning_effort` on chat completions and `reasoning.effort` on the Responses wire):
 
 ![Reasoning effort selector](https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-effort.png)
 
@@ -41,7 +41,7 @@ The `video_generate` tool plays the generated clip inline:
 | `codex`  | ChatGPT Plus/Pro  | live catalog from `chatgpt.com/backend-api/codex/models` |
 | `claude` | Claude Pro/Max    | all models available in your subscription (Opus, Sonnet, Haiku, Fable — static catalog, updated with the plugin) |
 | `grok`   | X Premium (xAI)   | live catalog from `api.x.ai/v1/models` (chat models only); reasoning efforts from the Grok CLI catalog (`cli-chat-proxy.grok.com/v1/models`) |
-| `copilot` | GitHub Copilot   | live catalog from `api.githubcopilot.com/models` (chat-completions models only, with per-model vision flags); login uses the OAuth device flow (enter the shown code at `github.com/login/device`) |
+| `copilot` | GitHub Copilot   | live catalog from `api.githubcopilot.com/models` (chat models on both wires, with per-model vision flags and reasoning efforts); login uses the OAuth device flow (enter the shown code at `github.com/login/device`) |
 
 Only logged-in providers appear in the session model picker; the lists above refresh on login/logout. Vision-capable models declare `['text', 'image']` input modalities, and image content is translated to each provider's wire format.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,15 @@ Not logged in? The provider stays out of the picker, and requests fail with `MIS
     models:                            # override the discovered/built-in catalogs
       codex:
         - { id: gpt-5.6-sol, name: GPT-5.6 Sol, contextWindow: 272000, inputModalities: [text, image] }
+      copilot:                         # manual entries disable Copilot catalog discovery
+        - { id: gpt-5.6-sol, wire: responses }   # copilot only: force the upstream protocol
 ```
+
+`wire` (copilot entries only) pins a model to `chat-completions` or `responses`. Manual
+entries keep working without it — the field exists because a configured model the live
+catalog does not know would otherwise default to `/chat/completions`, which
+responses-only families (gpt-5.5/5.6, …) reject. Pinning `chat-completions` also opts
+out of the tools+effort auto-reroute described above.
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Logged-in providers join the session model picker with their live model catalogs
 
 ![Model picker with subscription models](https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-picker.png)
 
-Models that advertise reasoning levels get an **Effort** selector in the same menu — Codex models, Grok 4.6 / 4.5, and Copilot's reasoning models (levels and defaults come from each provider's live catalog, not a hardcoded list; Copilot's `capabilities.supports.reasoning_effort` array is sent as `reasoning_effort` on chat completions and `reasoning.effort` on the Responses wire):
+Models that advertise reasoning levels get an **Effort** selector in the same menu — Codex models, Grok 4.6 / 4.5, and Copilot's reasoning models (levels and defaults come from each provider's live catalog, not a hardcoded list; Copilot's `capabilities.supports.reasoning_effort` array is sent as `reasoning_effort` on chat completions and `reasoning.effort` on the Responses wire). Models listing both Copilot endpoints (gpt-5.4, gpt-5-mini) normally speak chat completions but reroute to `/responses` when a request combines function tools with an effort — Copilot rejects that combination on the chat wire:
 
 ![Reasoning effort selector](https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-effort.png)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,7 +14,7 @@
 
 ![模型选择器中的订阅模型](https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-picker.png)
 
-声明了推理等级的模型会在同一菜单里多出**推理等级**选择 —— Codex 系列模型、Grok 4.6 / 4.5,以及 Copilot 的推理模型(档位和默认值来自各 provider 的实时目录,不是硬编码列表;Copilot 的 `capabilities.supports.reasoning_effort` 数组会按协议映射为 chat completions 的 `reasoning_effort` 或 Responses 的 `reasoning.effort`):
+声明了推理等级的模型会在同一菜单里多出**推理等级**选择 —— Codex 系列模型、Grok 4.6 / 4.5,以及 Copilot 的推理模型(档位和默认值来自各 provider 的实时目录,不是硬编码列表;Copilot 的 `capabilities.supports.reasoning_effort` 数组会按协议映射为 chat completions 的 `reasoning_effort` 或 Responses 的 `reasoning.effort`)。同时声明两个 Copilot 端点的模型(gpt-5.4、gpt-5-mini)默认走 chat completions,但请求同时携带函数工具和推理等级时会自动改走 `/responses` —— Copilot 在 chat 线路上拒绝这种组合:
 
 ![推理等级选择器](https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-effort.png)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,7 +14,7 @@
 
 ![模型选择器中的订阅模型](https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-picker.png)
 
-声明了推理等级的模型会在同一菜单里多出**推理等级**选择 —— Codex 系列模型,以及 Grok 4.6 / 4.5(档位和默认值来自各 provider 的实时目录,不是硬编码列表):
+声明了推理等级的模型会在同一菜单里多出**推理等级**选择 —— Codex 系列模型、Grok 4.6 / 4.5,以及 Copilot 的推理模型(档位和默认值来自各 provider 的实时目录,不是硬编码列表;Copilot 的 `capabilities.supports.reasoning_effort` 数组会按协议映射为 chat completions 的 `reasoning_effort` 或 Responses 的 `reasoning.effort`):
 
 ![推理等级选择器](https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-effort.png)
 
@@ -41,7 +41,7 @@
 | `codex`  | ChatGPT Plus/Pro | 从 `chatgpt.com/backend-api/codex/models` 实时获取 |
 | `claude` | Claude Pro/Max   | 订阅内所有可用模型(Opus、Sonnet、Haiku、Fable —— 静态目录,随插件更新) |
 | `grok`   | X Premium (xAI)  | 从 `api.x.ai/v1/models` 实时获取(仅对话模型);推理等级来自 Grok CLI 目录(`cli-chat-proxy.grok.com/v1/models`) |
-| `copilot` | GitHub Copilot  | 从 `api.githubcopilot.com/models` 实时获取(仅 chat-completions 模型,含按模型的视觉标记);登录使用 OAuth 设备码流程(在 `github.com/login/device` 输入页面显示的验证码) |
+| `copilot` | GitHub Copilot  | 从 `api.githubcopilot.com/models` 实时获取(两种 wire 的对话模型,含按模型的视觉标记与推理等级);登录使用 OAuth 设备码流程(在 `github.com/login/device` 输入页面显示的验证码) |
 
 只有已登录的 provider 才会出现在会话模型选择器里;登录/退出后列表自动刷新。支持视觉的模型会声明 `['text', 'image']` 输入模态,图片内容会被翻译成各 provider 的 wire 格式。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -122,7 +122,14 @@ GitHub 安装的:重新执行一遍 `add github:V1ki/dsh-plugin-subscriptions` �
     models:                            # 覆盖实时发现/内置目录
       codex:
         - { id: gpt-5.6-sol, name: GPT-5.6 Sol, contextWindow: 272000, inputModalities: [text, image] }
+      copilot:                         # 手工条目会关闭 Copilot 目录发现
+        - { id: gpt-5.6-sol, wire: responses }   # 仅 copilot:强制指定上游协议
 ```
+
+`wire`（仅 copilot 条目）把模型固定到 `chat-completions` 或 `responses`。不加该字段手工条目照常
+工作——它存在的原因是:实时目录不认识的手工模型否则会默认走 `/chat/completions`，而
+responses-only 系列（gpt-5.5/5.6 等）会拒绝该端点。固定为 `chat-completions` 也会退出上文所述
+tools+effort 的自动改道。
 
 ## 开发
 

--- a/scripts/manual/real-copilot-replay-probe.mjs
+++ b/scripts/manual/real-copilot-replay-probe.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+/**
+ * Minimal-traffic probe against the REAL GitHub Copilot gateway for the
+ * "Copilot Responses reasoning replay" path (CopilotAdapter +
+ * CopilotResponsesItemNormalizer + include:['reasoning.encrypted_content']).
+ *
+ * Budget: at most ONE GET /models (skipped entirely when the production
+ * durable catalog ~/.dsh/plugins/subscriptions/models.json already holds the
+ * Copilot entries — its data came from the same live endpoint) plus ONE
+ * POST /responses per phase-1 attempt (a stronger-prompt retry is allowed
+ * only when the model refused the tool) plus ONE POST /responses for the
+ * phase-2 replay. maxTokens is 800 on every generation. Nothing secret is
+ * ever printed: no tokens, no headers, no blob contents — only field names,
+ * lengths, and statuses. A proactive Copilot-token refresh (api.github.com,
+ * not the LLM gateway) may fire and write back to the real auth store; that
+ * is normal behavior.
+ *
+ * Phase 2 keeps the tools: the agent loop re-sends its tool list on every
+ * round, and that is what keeps a dual-protocol model (gpt-5.4) on /responses
+ * for the continuation — without tools the reroute rule (tools + effort)
+ * does not fire and the request degrades to /chat/completions, where no
+ * reasoning replay can ride at all.
+ *
+ * Env knobs:
+ *   PROBE_EFFORT=<id>     reasoning effort (default: low; from the catalog)
+ *   PROBE_LIVE_MODELS=1   force a live /models discovery (spends budget)
+ *   PROBE_PHASE1_ONLY=1   stop after phase 1 (single-request mode)
+ *   PROBE_SESSION=<id>    session id (default: probe-session)
+ *
+ * Usage: node scripts/manual/real-copilot-replay-probe.mjs
+ */
+import {
+  CopilotAdapter,
+  COPILOT_PREEMPT_MS,
+  fetchCopilotModels,
+  isCopilotPermanentRefreshError,
+  refreshCopilot,
+} from '../../lib/providers/copilot.js'
+import { TokenManager } from '../../lib/providers/common.js'
+import { catalogStore } from '../../lib/providers/catalog-store.js'
+import { deleteSession, getSession, saveSession } from '../../lib/auth/store.js'
+
+const BUDGET = Number(process.env.PROBE_BUDGET ?? 4) // hard cap on api.githubcopilot.com requests
+const MAX_TOKENS = 800
+const sessionId = process.env.PROBE_SESSION ?? 'probe-session' // branded ids are plain strings at runtime
+
+// ---------------------------------------------------------------- fetch tap
+// Records url/method/body of gateway calls (never headers) and tees the
+// /responses SSE stream so the RAW `response.output_item.done` item shapes
+// the gateway delivered are kept as direct evidence, beside the adapter's
+// own capture path.
+const realFetch = globalThis.fetch
+const copilotCalls = [] // { path, method, body, status } — bodies held, never printed wholesale
+const rawDoneItems = [] // shapes of done items from the CURRENT SSE stream
+let sawTerminalEvent = false
+function noteSseBlock(block) {
+  const data = block.split('\n').filter(line => line.startsWith('data:')).map(line => line.slice(5).trim()).join('\n')
+  if (data.length === 0) return
+  let event
+  try { event = JSON.parse(data) } catch { return }
+  if (event.type === 'response.output_item.done' && event.item !== undefined) {
+    const item = event.item
+    rawDoneItems.push({
+      type: item.type,
+      idLen: typeof item.id === 'string' ? item.id.length : 0,
+      encLen: typeof item.encrypted_content === 'string' ? item.encrypted_content.length : 0,
+      summaryParts: Array.isArray(item.summary) ? item.summary.length : 0,
+      status: typeof item.status === 'string' ? item.status : undefined,
+      ...(item.type === 'function_call'
+        ? { name: item.name, callIdLen: typeof item.call_id === 'string' ? item.call_id.length : 0 }
+        : {}),
+    })
+  }
+  if (event.type === 'response.completed' || event.type === 'response.failed' || event.type === 'response.incomplete') {
+    sawTerminalEvent = true
+  }
+}
+async function drainSse(branch) {
+  const reader = branch.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      let index
+      while ((index = buffer.indexOf('\n\n')) !== -1) {
+        noteSseBlock(buffer.slice(0, index))
+        buffer = buffer.slice(index + 2)
+      }
+    }
+  } catch { /* evidence drain only */ }
+}
+globalThis.fetch = async (input, init) => {
+  const url = typeof input === 'string' ? input : input.url
+  let response = await realFetch(input, init)
+  if (!url.startsWith('https://api.githubcopilot.com/')) return response
+  if (copilotCalls.length >= BUDGET) throw new Error('probe budget exhausted')
+  let body
+  try { body = typeof init?.body === 'string' ? JSON.parse(init.body) : undefined } catch { body = undefined }
+  copilotCalls.push({ path: new URL(url).pathname, method: init?.method ?? 'GET', body, status: response.status })
+  if (new URL(url).pathname === '/responses' && response.body !== null) {
+    const [forAdapter, forProbe] = response.body.tee()
+    void drainSse(forProbe)
+    response = new Response(forAdapter, { status: response.status, statusText: response.statusText, headers: response.headers })
+  }
+  return response
+}
+const callsTo = path => copilotCalls.filter(call => call.path === path)
+
+// ---------------------------------------------------- TokenManager (as src/)
+const tokens = new TokenManager({
+  displayName: 'GitHub Copilot',
+  preemptMs: COPILOT_PREEMPT_MS,
+  load: () => getSession('copilot'),
+  save: session => saveSession('copilot', session),
+  remove: () => deleteSession('copilot'),
+  refresh: refreshCopilot,
+  isPermanent: isCopilotPermanentRefreshError,
+  onRemoved: () => {},
+})
+
+// ---------------------------------------------------------------- discovery
+// The production durable catalog answers first (same live-gateway data, zero
+// budget); a live /models fetch happens only when it is absent or forced.
+const disk = process.env.PROBE_LIVE_MODELS === '1' ? undefined : await catalogStore('copilot').load().catch(() => undefined)
+let models
+let modelsSource
+if (disk !== undefined && disk.models.length > 0) {
+  models = disk.models
+  modelsSource = `durable catalog (${models.length} models, discovered ${new Date(disk.at).toISOString()})`
+} else {
+  models = await fetchCopilotModels(await tokens.session())
+  modelsSource = 'live GET /models'
+}
+const effortsOf = entry => entry.reasoning?.efforts?.map(effort => String(effort.id)) ?? []
+const preferred = models.find(entry => entry.id === 'gpt-5.4' && effortsOf(entry).length > 0)
+const responsesWithEfforts = models.filter(entry => entry.copilotWire === 'responses' && effortsOf(entry).length > 0)
+const chosen = preferred ?? responsesWithEfforts[0]
+  ?? models.find(entry => entry.copilotWire === 'responses') ?? models[0]
+if (chosen === undefined) throw new Error('copilot catalog is empty')
+const efforts = effortsOf(chosen)
+const effort = process.env.PROBE_EFFORT !== undefined
+  ? (efforts.includes(process.env.PROBE_EFFORT) || efforts.length === 0 ? process.env.PROBE_EFFORT : undefined)
+  : (efforts.includes('low') ? 'low' : (chosen.copilotWire !== 'responses' && efforts.length > 0 ? efforts[0] : undefined))
+if (process.env.PROBE_EFFORT !== undefined && effort === undefined) {
+  throw new Error(`PROBE_EFFORT=${process.env.PROBE_EFFORT} is not advertised for ${chosen.id} (has: ${efforts.join(',') || 'none'})`)
+}
+
+// Seed the adapter's catalog cache as FRESH so its discovered() never spends
+// a second /models request (budget); entries are the same live-gateway data.
+const seededAt = Date.now()
+const seedStore = {
+  load: async () => ({ at: seededAt, models }),
+  save: async () => {},
+  clear: async () => {},
+}
+const warns = []
+const adapter = new CopilotAdapter({
+  models: [],
+  streamIdleTimeoutMs: 300_000,
+  tokens,
+  discovery: true,
+  onWarn: message => { warns.push(message) },
+  catalogStore: seedStore,
+})
+
+// ------------------------------------------------------------------ helpers
+const text = value => `"${String(value).slice(0, 80).replace(/\s+/g, ' ')}"`
+async function generate(options) {
+  rawDoneItems.length = 0
+  sawTerminalEvent = false
+  const blocks = []
+  let finish
+  try {
+    for await (const chunk of adapter.stream(options)) {
+      if (chunk.type === 'block-end') blocks.push(chunk.block)
+      if (chunk.type === 'finish') finish = chunk.reason.kind
+    }
+  } catch (error) {
+    return { blocks, finish, error: String(error.message ?? error), doneItems: [...rawDoneItems], sseTerminal: sawTerminalEvent }
+  }
+  return { blocks, finish, error: undefined, doneItems: [...rawDoneItems], sseTerminal: sawTerminalEvent }
+}
+const weatherTool = {
+  name: 'get_weather',
+  description: 'Get the current weather for a city.',
+  parameters: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] },
+}
+const userMessage = prompt => ({
+  id: 'probe-msg-1',
+  role: 'user',
+  content: [{ type: 'text', text: prompt }],
+  source: { kind: 'user' },
+})
+const baseOptions = prompt => ({
+  provider: 'copilot',
+  model: chosen.id,
+  sessionId,
+  maxTokens: MAX_TOKENS,
+  tools: [weatherTool],
+  ...(effort !== undefined ? { reasoningEffort: effort } : {}),
+  messages: [userMessage(prompt)],
+})
+
+// ------------------------------------------------------------------ phase 1
+let phase1 = await generate(baseOptions("What's the weather in Paris? You MUST call the get_weather tool."))
+let promptUsed = 'plain'
+const toolCallsOf = result => result.blocks.filter(block => block.type === 'tool-call')
+if (toolCallsOf(phase1).length === 0 && callsTo('/responses').length + callsTo('/chat/completions').length < BUDGET - 1) {
+  promptUsed = 'forced'
+  phase1 = await generate(baseOptions('What is the weather in Paris right now? You MUST call the get_weather tool first. Do NOT answer from your own knowledge; calling the tool is mandatory.'))
+}
+const reasoningBlock = phase1.blocks.find(block => block.type === 'reasoning')
+const toolCalls = toolCallsOf(phase1)
+const rawReasoningDone = phase1.doneItems.filter(item => item.type === 'reasoning')
+const capturedScopes = adapter.replayByScope.size // >0 ⇔ some done reasoning item carried id + encrypted_content
+
+// ------------------------------------------------------------------ phase 2
+let phase2
+let replay = { present: false }
+let phase2Wire = 'skipped'
+if (process.env.PROBE_PHASE1_ONLY !== '1' && toolCalls.length > 0
+  && callsTo('/responses').length + callsTo('/chat/completions').length < BUDGET) {
+  const assistant = {
+    id: 'probe-msg-2',
+    role: 'assistant',
+    content: [...(reasoningBlock === undefined ? [] : [reasoningBlock]), ...toolCalls],
+    source: { kind: 'model', provider: 'copilot', model: chosen.id },
+  }
+  const callId = toolCalls[0].id
+  const toolResult = {
+    id: 'probe-msg-3',
+    role: 'user',
+    content: [{
+      type: 'tool-result',
+      toolCallId: callId,
+      content: [{ type: 'text', text: 'Sunny, 18°C, light wind from the west.' }],
+    }],
+    source: { kind: 'tool', callId },
+  }
+  const before = copilotCalls.length
+  // Tools stay in: the agent loop re-sends them every round, and they are
+  // what keeps a dual-protocol model on /responses for the continuation.
+  phase2 = await generate({
+    provider: 'copilot',
+    model: chosen.id,
+    sessionId,
+    maxTokens: MAX_TOKENS,
+    tools: [weatherTool],
+    system: 'Answer very briefly.',
+    ...(effort !== undefined ? { reasoningEffort: effort } : {}),
+    messages: [userMessage("What's the weather in Paris? You MUST call the get_weather tool."), assistant, toolResult],
+  })
+  const phase2Calls = copilotCalls.slice(before)
+  const onResponses = phase2Calls.find(call => call.path === '/responses')
+  phase2Wire = onResponses !== undefined ? '/responses' : (phase2Calls[0]?.path ?? 'none')
+  if (onResponses !== undefined) {
+    const input = onResponses.body?.input ?? []
+    const reasoningItems = input.filter(item => item?.type === 'reasoning')
+    const lastReasoningIndex = reasoningItems.length > 0 ? input.lastIndexOf(reasoningItems.at(-1)) : -1
+    const callIndex = input.findIndex(item => item?.type === 'function_call')
+    replay = {
+      present: reasoningItems.length > 0,
+      items: reasoningItems.map(item => ({
+        idLen: typeof item.id === 'string' ? item.id.length : 0,
+        encLen: typeof item.encrypted_content === 'string' ? item.encrypted_content.length : 0,
+        summaryParts: Array.isArray(item.summary) ? item.summary.length : 0,
+        status: typeof item.status === 'string' ? item.status : undefined,
+      })),
+      adjacent: reasoningItems.length > 0 && callIndex === lastReasoningIndex + 1,
+      include: Array.isArray(onResponses.body?.include) ? onResponses.body.include : [],
+      status: onResponses.status,
+    }
+  }
+}
+
+// ------------------------------------------------------------------ summary
+const lines = []
+lines.push(`model: ${chosen.id} | catalog copilotWire=${chosen.copilotWire ?? 'n/a'} copilotResponses=${String(chosen.copilotResponses === true)} | efforts=[${efforts.join(',') || 'none'}] effort=${effort ?? 'none'} | models: ${modelsSource}`)
+lines.push(`wire taken: ${callsTo('/responses').length > 0 ? 'POST /responses' : 'n/a'} | reroute=${chosen.copilotWire === 'chat-completions' && callsTo('/responses').length > 0 ? 'yes (auto)' : 'no'} | prompt=${promptUsed}`)
+lines.push(`budget: ${copilotCalls.length}/${BUDGET} gateway calls -> ${copilotCalls.map(call => `${call.method} ${call.path}:${call.status}`).join(' | ') || 'none'}`)
+const phase1Status = callsTo('/responses')[0]?.status ?? 'n/a'
+lines.push(`phase1: ${phase1Status} HTTP | finish=${phase1.finish ?? 'error'} | reasoning-block=${reasoningBlock !== undefined ? `yes (${reasoningBlock.text.length} chars)` : 'no'} | tool-calls=${toolCalls.map(call => `${call.name}(id ${String(call.id).length}b)`).join(',') || 'none'}${phase1.error === undefined ? '' : ` | ERROR ${phase1.error.slice(0, 300)}`}`)
+lines.push(`phase1 raw SSE done items: ${phase1.doneItems.map(item => `${item.type}{id:${item.idLen}b,enc:${item.encLen}b,summary:${item.summaryParts},status:${item.status ?? 'absent'}}`).join(' ; ') || 'none'} | terminal-event=${String(phase1.sseTerminal)}`)
+lines.push(`capture: adapter replay scopes=${capturedScopes} -> gateway ${capturedScopes > 0 ? 'DID deliver id+encrypted_content on a reasoning done item' : 'delivered NO reasoning item with id+encrypted_content'} (raw reasoning done items: ${rawReasoningDone.length})`)
+if (phase2 !== undefined) {
+  if (replay.present || phase2Wire === '/responses') {
+    lines.push(`phase2 wire=${phase2Wire} | replay request reasoning items=${replay.items.length} | fields: ${replay.items.map(item => `id(${item.idLen}b) enc(${item.encLen}b) summary(${item.summaryParts} parts) status=${item.status ?? 'absent'}`).join(' ; ') || 'NONE (nothing captured to replay)'} | adjacent-before-function_call=${String(replay.adjacent)} | include=[${replay.include.join(',')}]`)
+  } else {
+    lines.push(`phase2 wire=${phase2Wire} | replay structurally impossible on this wire (no tools+effort reroute; toChatMessages drops reasoning blocks)`)
+  }
+  const finalText = phase2.blocks.filter(block => block.type === 'text').map(block => block.text).join('')
+  lines.push(`phase2: ${replay.status ?? copilotCalls.at(-1)?.status ?? 'n/a'} HTTP | finish=${phase2.finish ?? 'error'}${phase2.error === undefined ? '' : ` | ERROR ${phase2.error.slice(0, 300)}`} | text=${text(finalText)}`)
+} else {
+  lines.push('phase2: skipped (PROBE_PHASE1_ONLY or no tool call captured or budget spent)')
+}
+let verdict
+if (phase2 !== undefined && replay.present && replay.status !== undefined && replay.status >= 200 && replay.status < 300 && phase2.error === undefined) {
+  verdict = '(a) FULL REPLAY ACCEPTED by the real gateway (reasoning item with encrypted_content replayed before its function_call; 2xx and the SSE stream ran to completion)'
+} else if (phase2 !== undefined && phase2Wire === '/responses' && !replay.present && replay.status !== undefined && replay.status >= 200 && replay.status < 300) {
+  verdict = '(b) gateway delivered no encrypted_content -> replay lazily degraded (phase-2 /responses request carried NO reasoning item; the no-replay path was accepted)'
+} else if (phase2 !== undefined && replay.present) {
+  verdict = `(c) gateway REJECTED the replay shape -> see phase2 ERROR above (HTTP ${String(replay.status)})`
+} else if (phase2 !== undefined) {
+  verdict = `partial: phase-2 request went to ${phase2Wire}; replay wire not exercised in this run`
+} else {
+  verdict = capturedScopes > 0
+    ? 'phase-1 only: gateway DID deliver encrypted_content (replay would be attempted); acceptance not tested this run'
+    : 'phase-1 only: gateway delivered NO encrypted_content -> replay would lazily degrade (b)'
+}
+lines.push(`VERDICT: ${verdict}`)
+if (warns.length > 0) lines.push(`warns: ${warns.join(' | ').slice(0, 200)}`)
+console.log(lines.join('\n'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,7 @@ const modelEntrySchema: z<ModelEntry> = z.object({
   contextWindow: z.number().step(1).min(1),
   maxTokens: z.number().step(1).min(1),
   inputModalities: z.array(z.union(['text', 'image'])),
+  wire: z.union(['chat-completions', 'responses']),
 })
 
 export const Config: z<Config> = z.object({

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,6 +392,10 @@ export function apply(ctx: Context, config: Config): void {
   // picker re-query `listModels` and show/hide the provider.
   const handles = new Map<ProviderId, AdapterRegistrationHandle>()
   const authChanged = (provider: ProviderId): void => {
+    // Login, logout, and credential death all pass through here; a copilot
+    // auth transition also drops the adapter's captured reasoning replay
+    // state (isolation is already account-scoped — this is memory hygiene).
+    if (provider === 'copilot') copilotAdapter?.clearReplayState()
     handles.get(provider)?.replace([provider])
   }
   // Token managers double as the tools' credential source, so they are
@@ -407,6 +411,9 @@ export function apply(ctx: Context, config: Config): void {
   // fast-tier support so a stale choice cannot leak onto a plain model.
   const speedBySession = new Map<string, SpeedTier>()
   let codexAdapter: CodexAdapter | undefined
+  // Dropped on every copilot auth transition so replay state (captured
+  // reasoning) never survives an account switch in memory.
+  let copilotAdapter: CopilotAdapter | undefined
 
   for (const provider of providers) {
     switch (provider) {
@@ -505,7 +512,7 @@ export function apply(ctx: Context, config: Config): void {
           isPermanent: isCopilotPermanentRefreshError,
           onRemoved: () => { authChanged('copilot') },
         })
-        handles.set('copilot', ctx.llm.registerAdapter(['copilot'], new CopilotAdapter({
+        copilotAdapter = new CopilotAdapter({
           models: catalog.copilot,
           streamIdleTimeoutMs,
           tokens,
@@ -515,7 +522,8 @@ export function apply(ctx: Context, config: Config): void {
           // Durable catalog: capability metadata (per-model vision support,
           // context windows) survives restarts and network failures.
           catalogStore: catalogStore('copilot'),
-        })))
+        })
+        handles.set('copilot', ctx.llm.registerAdapter(['copilot'], copilotAdapter))
         break
       }
     }

--- a/src/providers/catalog-store.ts
+++ b/src/providers/catalog-store.ts
@@ -76,6 +76,12 @@ function sanitizeModel(value: unknown): DiscoveredModel | undefined {
   if (thinkingType !== undefined && thinkingType !== 'enabled' && thinkingType !== 'adaptive') return undefined
   const fastTier = raw.fastTier
   if (fastTier !== undefined && typeof fastTier !== 'boolean') return undefined
+  const copilotWire = raw.copilotWire
+  if (copilotWire !== undefined && copilotWire !== 'chat-completions' && copilotWire !== 'responses') {
+    return undefined
+  }
+  const copilotResponses = raw.copilotResponses
+  if (copilotResponses !== undefined && typeof copilotResponses !== 'boolean') return undefined
   const inputModalities = raw.inputModalities
   if (inputModalities !== undefined
     && (!Array.isArray(inputModalities) || inputModalities.length === 0
@@ -89,6 +95,8 @@ function sanitizeModel(value: unknown): DiscoveredModel | undefined {
     ...reasoning === undefined ? {} : { reasoning },
     ...thinkingType === undefined ? {} : { thinkingType: thinkingType as 'enabled' | 'adaptive' },
     ...fastTier === undefined ? {} : { fastTier },
+    ...copilotWire === undefined ? {} : { copilotWire: copilotWire as 'chat-completions' | 'responses' },
+    ...copilotResponses === undefined ? {} : { copilotResponses },
     ...inputModalities === undefined ? {} : { inputModalities: [...inputModalities] as ('text' | 'image')[] },
   }
 }

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -370,6 +370,12 @@ export interface DiscoveredModel {
   fastTier?: boolean
   /** Copilot-specific: which upstream protocol the model's endpoints speak. */
   copilotWire?: 'chat-completions' | 'responses'
+  /**
+   * Copilot-specific: the catalog also lists `/responses` for this model
+   * (dual-protocol entries, e.g. gpt-5.4), so a chat-wire request may reroute
+   * there when it combines function tools with a reasoning effort.
+   */
+  copilotResponses?: boolean
 }
 
 /** How long a discovered catalog is trusted before re-fetching. */

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -368,6 +368,8 @@ export interface DiscoveredModel {
   thinkingType?: 'enabled' | 'adaptive'
   /** Codex-specific: the catalog advertises a fast (priority) service tier. */
   fastTier?: boolean
+  /** Copilot-specific: which upstream protocol the model's endpoints speak. */
+  copilotWire?: 'chat-completions' | 'responses'
 }
 
 /** How long a discovered catalog is trusted before re-fetching. */

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -27,6 +27,12 @@ export interface ModelEntry {
   maxTokens?: number
   /** Accepted request modalities; when set, wins over the provider default. */
   inputModalities?: ('text' | 'image')[]
+  /**
+   * Force this model's upstream protocol. Only the copilot adapter consumes
+   * the semantics; the union is inlined here to avoid a circular import of
+   * the copilot module's `CopilotWire`.
+   */
+  wire?: 'chat-completions' | 'responses'
 }
 
 /**
@@ -54,6 +60,9 @@ export function validateModels(models: readonly ModelEntry[], label: string): Mo
         || model.inputModalities.some(modality => modality !== 'text' && modality !== 'image'))) {
       throw new Error(`${label}: catalog model "${model.id}" inputModalities must be a non-empty list of "text"/"image"`)
     }
+    if (model.wire !== undefined && model.wire !== 'chat-completions' && model.wire !== 'responses') {
+      throw new Error(`${label}: catalog model "${model.id}" wire must be "chat-completions" or "responses"`)
+    }
     if (seen.has(model.id)) throw new Error(`${label}: duplicate catalog model "${model.id}"`)
     seen.add(model.id)
     return {
@@ -62,6 +71,7 @@ export function validateModels(models: readonly ModelEntry[], label: string): Mo
       ...model.contextWindow === undefined ? {} : { contextWindow: model.contextWindow },
       ...model.maxTokens === undefined ? {} : { maxTokens: model.maxTokens },
       ...model.inputModalities === undefined ? {} : { inputModalities: [...model.inputModalities] },
+      ...model.wire === undefined ? {} : { wire: model.wire },
     }
   })
 }

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -14,7 +14,7 @@
  * unchanged.
  */
 
-import { EMPTY_RESPONSE_CODE, errorChain, LlmAdapter, LlmError } from '@deepseek-ai/dsh-llm'
+import { EMPTY_RESPONSE_CODE, errorChain, LlmAdapter, LlmError, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type {
   GenerateOptions,
   LlmModelInfo,
@@ -266,9 +266,38 @@ interface CopilotWireModel {
   policy?: { state?: string }
   supported_endpoints?: string[]
   capabilities?: {
-    supports?: { vision?: boolean; tool_calls?: boolean }
+    supports?: {
+      vision?: boolean
+      tool_calls?: boolean
+      /** Supported reasoning efforts, present only on models that reason. */
+      reasoning_effort?: string[] | null
+    }
     limits?: { max_context_window_tokens?: number }
   }
+}
+
+/** Display name for one Copilot wire reasoning-effort value. */
+function copilotEffortName(effort: string): string {
+  return effort === 'xhigh' ? 'Extra High' : effort.charAt(0).toUpperCase() + effort.slice(1)
+}
+
+/**
+ * Map a catalog entry's `supports.reasoning_effort` array into selectable
+ * efforts. The endpoint discloses no default effort, so none is claimed
+ * (absence preserves the provider's own default). Duplicates and non-string
+ * entries are dropped: the harness rejects duplicate effort ids outright.
+ */
+function copilotReasoning(entry: CopilotWireModel): { efforts: { id: ReasoningEffortId; name: string }[] } | undefined {
+  const wire = entry.capabilities?.supports?.reasoning_effort
+  if (!Array.isArray(wire)) return undefined
+  const seen = new Set<string>()
+  const efforts: { id: ReasoningEffortId; name: string }[] = []
+  for (const value of wire) {
+    if (typeof value !== 'string' || value.length === 0 || seen.has(value)) continue
+    seen.add(value)
+    efforts.push({ id: ReasoningEffortId(value), name: copilotEffortName(value) })
+  }
+  return efforts.length > 0 ? { efforts } : undefined
 }
 
 /**
@@ -278,7 +307,9 @@ interface CopilotWireModel {
  * the chat wire, one listing only `/responses` (the newer GPT families,
  * e.g. gpt-5.6) speaks the Responses wire, and the choice is recorded on the
  * discovered entry so requests pick the matching endpoint. Vision support
- * from the catalog becomes the model's input modalities.
+ * from the catalog becomes the model's input modalities, and a non-empty
+ * `supports.reasoning_effort` array becomes the model's selectable reasoning
+ * efforts (the endpoint discloses no default, so none is claimed).
  * @param session - the stored session (used as-is; never refreshed here).
  * @param fetchFn - fetch implementation (injectable for tests).
  * @returns discovered chat models in endpoint order.
@@ -309,6 +340,7 @@ export async function fetchCopilotModels(
       else continue
     }
     seen.add(entry.id)
+    const reasoning = copilotReasoning(entry)
     discovered.push({
       id: entry.id,
       name: typeof entry.name === 'string' && entry.name.length > 0 ? entry.name : entry.id,
@@ -317,6 +349,7 @@ export async function fetchCopilotModels(
         ? { contextWindow: entry.capabilities.limits.max_context_window_tokens }
         : {},
       inputModalities: entry.capabilities?.supports?.vision === true ? ['text', 'image'] : ['text'],
+      ...reasoning === undefined ? {} : { reasoning },
       ...wire === undefined ? {} : { copilotWire: wire },
     })
   }
@@ -361,6 +394,12 @@ export function copilotChatRequestBody(
       ? { tools: toChatTools(options.tools), tool_choice: 'auto' }
       : {},
     ...options.maxTokens !== undefined ? { max_completion_tokens: options.maxTokens } : {},
+    // The harness only passes an effort the resolved model advertised (the
+    // catalog's reasoning_effort array), so this never reaches a model that
+    // would reject it with 400 invalid_request_body.
+    ...options.reasoningEffort !== undefined
+      ? { reasoning_effort: String(options.reasoningEffort) }
+      : {},
     // The upstream is stream-only; usage arrives on the terminal chunk.
     stream: true,
     stream_options: { include_usage: true },
@@ -386,6 +425,11 @@ export function copilotResponsesRequestBody(
       ? { tools: toResponsesTools(options.tools), tool_choice: 'auto' }
       : {},
     ...options.maxTokens !== undefined ? { max_output_tokens: options.maxTokens } : {},
+    // The Responses wire spells the effort nested; only advertised efforts
+    // ever reach this branch (see copilotChatRequestBody).
+    ...options.reasoningEffort !== undefined
+      ? { reasoning: { effort: String(options.reasoningEffort) } }
+      : {},
     stream: true,
   }
 }
@@ -529,6 +573,11 @@ export class CopilotAdapter extends LlmAdapter {
       inputModalities: discovered?.inputModalities ?? configured?.inputModalities ?? ['text'],
       context: { contextWindow: discovered?.contextWindow ?? configured?.contextWindow ?? COPILOT_CONTEXT_WINDOW },
       defaultMaxTokens: configured?.maxTokens ?? COPILOT_DEFAULT_MAX_TOKENS,
+      // Efforts come from the discovered catalog's reasoning_effort array; a
+      // model that did not advertise one exposes none, so the harness rejects
+      // an explicit effort before provider I/O instead of the API 400ing
+      // (Copilot returns invalid_request_body for models that cannot reason).
+      ...discovered?.reasoning === undefined ? {} : { reasoning: discovered.reasoning },
     }
   }
 

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -306,10 +306,12 @@ function copilotReasoning(entry: CopilotWireModel): { efforts: { id: ReasoningEf
  * protocol this adapter knows: an entry listing `/chat/completions` speaks
  * the chat wire, one listing only `/responses` (the newer GPT families,
  * e.g. gpt-5.6) speaks the Responses wire, and the choice is recorded on the
- * discovered entry so requests pick the matching endpoint. Vision support
- * from the catalog becomes the model's input modalities, and a non-empty
- * `supports.reasoning_effort` array becomes the model's selectable reasoning
- * efforts (the endpoint discloses no default, so none is claimed).
+ * discovered entry so requests pick the matching endpoint; an entry listing
+ * BOTH endpoints additionally records `/responses` availability, which
+ * {@link copilotRequestWire} uses to reroute tools+effort requests. Vision
+ * support from the catalog becomes the model's input modalities, and a
+ * non-empty `supports.reasoning_effort` array becomes the model's selectable
+ * reasoning efforts (the endpoint discloses no default, so none is claimed).
  * @param session - the stored session (used as-is; never refreshed here).
  * @param fetchFn - fetch implementation (injectable for tests).
  * @returns discovered chat models in endpoint order.
@@ -334,9 +336,11 @@ export async function fetchCopilotModels(
     if (typeof entry.id !== 'string' || entry.id.length === 0 || seen.has(entry.id)) continue
     if (entry.model_picker_enabled !== true || entry.policy?.state === 'disabled') continue
     let wire: 'chat-completions' | 'responses' | undefined
+    let responsesSupported = false
     if (Array.isArray(entry.supported_endpoints)) {
+      responsesSupported = entry.supported_endpoints.includes('/responses')
       if (entry.supported_endpoints.includes('/chat/completions')) wire = 'chat-completions'
-      else if (entry.supported_endpoints.includes('/responses')) wire = 'responses'
+      else if (responsesSupported) wire = 'responses'
       else continue
     }
     seen.add(entry.id)
@@ -351,6 +355,7 @@ export async function fetchCopilotModels(
       inputModalities: entry.capabilities?.supports?.vision === true ? ['text', 'image'] : ['text'],
       ...reasoning === undefined ? {} : { reasoning },
       ...wire === undefined ? {} : { copilotWire: wire },
+      ...responsesSupported ? { copilotResponses: true } : {},
     })
   }
   // An empty catalog from a 200 response is treated as a discovery failure so
@@ -375,6 +380,32 @@ export function copilotWireFor(entry: DiscoveredModel | undefined): CopilotWire 
 }
 
 /**
+ * The upstream protocol for ONE REQUEST: the model's default wire, except
+ * that a dual-protocol model defaulting to chat completions must reroute to
+ * Responses when the request combines function tools with a reasoning effort
+ * — Copilot rejects exactly that combination on /chat/completions with
+ * HTTP 400 invalid_request_body ("Function tools with reasoning_effort are
+ * not supported … use /v1/responses or set reasoning_effort to 'none'",
+ * observed on gpt-5.4) while /responses serves it. Effort 'none' stays on
+ * the chat wire (the API allows the combination there), and models not
+ * listing /responses never reroute.
+ * @param entry - the discovered catalog entry, when known.
+ * @param options - the harness generate options (tools + effort only).
+ * @returns the protocol the request for this model must speak.
+ */
+export function copilotRequestWire(
+  entry: DiscoveredModel | undefined,
+  options: Pick<GenerateOptions, 'tools' | 'reasoningEffort'>,
+): CopilotWire {
+  const wire = copilotWireFor(entry)
+  if (wire !== 'chat-completions') return wire
+  if (entry?.copilotResponses !== true) return wire
+  if (options.tools === undefined || options.tools.length === 0) return wire
+  if (options.reasoningEffort === undefined || options.reasoningEffort === 'none') return wire
+  return 'responses'
+}
+
+/**
  * The chat completions request body for one generation. The output cap rides
  * `max_completion_tokens` — the newer OpenAI-family models on Copilot reject
  * the legacy `max_tokens` parameter outright (HTTP 400 "Unsupported
@@ -395,8 +426,8 @@ export function copilotChatRequestBody(
       : {},
     ...options.maxTokens !== undefined ? { max_completion_tokens: options.maxTokens } : {},
     // The harness only passes an effort the resolved model advertised (the
-    // catalog's reasoning_effort array), so this never reaches a model that
-    // would reject it with 400 invalid_request_body.
+    // catalog's reasoning_effort array), and copilotRequestWire keeps the
+    // tools+effort combination off this wire for models that reject it.
     ...options.reasoningEffort !== undefined
       ? { reasoning_effort: String(options.reasoningEffort) }
       : {},
@@ -585,8 +616,10 @@ export class CopilotAdapter extends LlmAdapter {
     const watchdog = idleWatchdog(options.signal, this.options.streamIdleTimeoutMs)
     try {
       // The discovered catalog decides the protocol: `/responses`-only model
-      // families (gpt-5.5/5.6, …) reject /chat/completions outright.
-      const wire = copilotWireFor(await this.discovered(options.model))
+      // families (gpt-5.5/5.6, …) reject /chat/completions outright, and
+      // dual-protocol models reroute there once the request combines function
+      // tools with a reasoning effort (gpt-5.4 400s on the chat wire then).
+      const wire = copilotRequestWire(await this.discovered(options.model), options)
       let session = await this.options.tokens.session()
       let response = await this.request(options, session, watchdog.signal, wire)
       if (response.status === 401) {

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -473,16 +473,31 @@ export function copilotResponsesRequestBody(
  * assembly in the shared translator: text fragments would each open their
  * own block, `done` would synthesize duplicates, and a function call whose
  * arguments arrive whole only on `done` (the deltas carry empty strings)
- * would close empty. Events of one item are contiguous on the wire, so the
- * item's ordinal — assigned at `output_item.added` and reused until the next
- * one — is a faithful stable key. Function-call identity additionally rides
- * the gateway-stable `call_id`.
+ * would close empty. The stable key derives from the event's `output_index`
+ * — the item's position in the response's output array, which survives the
+ * gateway's per-event id churn even when two items' events interleave on
+ * the wire (parallel tool calls do exactly that). Events without an
+ * `output_index` fall back to the key of the last `output_item.added`, which
+ * is only correct while one item's events stay contiguous — the pre-
+ * interleaving behavior, kept for gateways that omit the field; with no
+ * `added` seen yet they key to `copilot-item-0` as before. Function-call
+ * identity additionally rides the gateway-stable `call_id`.
  */
 export class CopilotResponsesItemNormalizer {
-  private ordinal = 0
+  private adds = 0
+  private lastKey = 'copilot-item-0'
 
-  private get key(): string {
-    return `copilot-item-${String(this.ordinal)}`
+  /**
+   * [2026-08-23]-[a single arrival-order ordinal mis-buckets every event after
+   * a second item's `added`, mangling interleaved parallel tool calls;
+   * output_index is the only correlator the gateway keeps stable]-[changes
+   * keys only for streams that carry output_index; no-index streams keep the
+   * old last-added-key behavior byte for byte]
+   */
+  private keyFor(event: ResponsesStreamEvent): string {
+    return event.output_index !== undefined
+      ? `copilot-item-${String(event.output_index)}`
+      : this.lastKey
   }
 
   /**
@@ -492,18 +507,23 @@ export class CopilotResponsesItemNormalizer {
    */
   push(event: ResponsesStreamEvent): ResponsesStreamEvent {
     if (event.type === 'response.output_item.added') {
-      this.ordinal += 1
+      this.adds += 1
+      const key = event.output_index !== undefined
+        ? `copilot-item-${String(event.output_index)}`
+        : `copilot-item-${String(this.adds)}`
+      this.lastKey = key
       return event.item === undefined
         ? event
-        : { ...event, item: { ...event.item, id: this.key } }
+        : { ...event, item: { ...event.item, id: key } }
     }
+    const key = this.keyFor(event)
     if (event.type === 'response.output_item.done') {
       return event.item === undefined
         ? event
-        : { ...event, item: { ...event.item, id: this.key } }
+        : { ...event, item: { ...event.item, id: key } }
     }
     if (event.item_id === undefined) return event
-    return { ...event, item_id: this.key }
+    return { ...event, item_id: key }
   }
 }
 

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -32,7 +32,7 @@ import {
   toChatTools,
 } from '../translate/chat-completions.js'
 import { streamResponses, toResponsesInput, toResponsesTools } from '../translate/responses.js'
-import type { ResponsesRequestInput, ResponsesStreamEvent } from '../translate/responses.js'
+import type { ReasoningReplayItem, ResponsesRequestInput, ResponsesStreamEvent } from '../translate/responses.js'
 import {
   httpLlmError,
   idleWatchdog,
@@ -470,6 +470,27 @@ export function copilotResponsesRequestBody(
 }
 
 /**
+ * The replayable form of one completed reasoning item: the COMPLETE item as
+ * the gateway delivered it on `response.output_item.done` — its ORIGINAL id
+ * (captured before the stable-key rewrite), summary parts, status, and the
+ * encrypted payload. A reasoning item's `id` and `summary` are not optional
+ * in the Responses input schema, so an item missing its id or its blob is
+ * not replayable and degrades to the no-replay path instead of risking an
+ * invalid input item.
+ */
+function completedReasoningItem(item: NonNullable<ResponsesStreamEvent['item']>): ReasoningReplayItem | undefined {
+  if (typeof item.encrypted_content !== 'string' || item.encrypted_content.length === 0) return undefined
+  if (typeof item.id !== 'string' || item.id.length === 0) return undefined
+  return {
+    type: 'reasoning',
+    id: item.id,
+    ...Array.isArray(item.summary) ? { summary: item.summary } : {},
+    ...typeof item.status === 'string' && item.status.length > 0 ? { status: item.status } : {},
+    encrypted_content: item.encrypted_content,
+  }
+}
+
+/**
  * Rewrite Copilot's Responses-gateway item ids into stable per-item keys.
  * Unlike chatgpt.com's Responses backend, the Copilot gateway mints a FRESH
  * opaque `item.id`/`item_id` on every event of one response (the `added`,
@@ -490,17 +511,17 @@ export function copilotResponsesRequestBody(
 export class CopilotResponsesItemNormalizer {
   private adds = 0
   private lastKey = 'copilot-item-0'
-  /** Call ids and encrypted reasoning blobs collected for the open response. */
+  /** Call ids and completed reasoning items collected for the open response. */
   private capturedCallIds: string[] = []
-  private capturedEncrypted: string[] = []
+  private capturedReasoning: ReasoningReplayItem[] = []
 
   /**
    * @param onCaptured - fired at each `response.completed` that produced BOTH
-   *   function calls and encrypted reasoning, receiving the response's call
-   *   ids and encrypted blobs so the adapter can replay them on the next
-   *   request.
+   *   function calls and completed reasoning items, receiving the response's
+   *   call ids and replayable reasoning items so the adapter can replay them
+   *   on the next request.
    */
-  constructor(private readonly onCaptured?: (callIds: string[], encrypted: string[]) => void) {}
+  constructor(private readonly onCaptured?: (callIds: string[], items: ReasoningReplayItem[]) => void) {}
 
   /**
    * [2026-08-23]-[a single arrival-order ordinal mis-buckets every event after
@@ -537,9 +558,11 @@ export class CopilotResponsesItemNormalizer {
     }
     if (event.type === 'response.output_item.done') {
       const item = event.item
-      if (item?.type === 'reasoning'
-        && typeof item.encrypted_content === 'string' && item.encrypted_content.length > 0) {
-        this.capturedEncrypted.push(item.encrypted_content)
+      if (item?.type === 'reasoning') {
+        // Capture runs BEFORE the stable-key rewrite: the replay item must
+        // carry the item's original gateway id, not the translator key.
+        const captured = completedReasoningItem(item)
+        if (captured !== undefined) this.capturedReasoning.push(captured)
       }
       return item === undefined
         ? event
@@ -548,11 +571,11 @@ export class CopilotResponsesItemNormalizer {
     if (event.type === 'response.completed') {
       // Both sides present is the only replayable response; clear either way —
       // one SSE stream may carry multiple responses.
-      if (this.capturedCallIds.length > 0 && this.capturedEncrypted.length > 0) {
-        this.onCaptured?.(this.capturedCallIds, this.capturedEncrypted)
+      if (this.capturedCallIds.length > 0 && this.capturedReasoning.length > 0) {
+        this.onCaptured?.(this.capturedCallIds, this.capturedReasoning)
       }
       this.capturedCallIds = []
-      this.capturedEncrypted = []
+      this.capturedReasoning = []
       return event
     }
     if (event.item_id === undefined) return event
@@ -577,19 +600,33 @@ export interface CopilotAdapterOptions {
   catalogStore?: CatalogPersistence
 }
 
+/** One captured replay bundle: a response's completed reasoning items. */
+interface ReasoningReplayEntry {
+  /** Completed reasoning items in output order, replayed ahead of the response's first function call. */
+  items: ReasoningReplayItem[]
+  /** Capture time (epoch ms); entries older than the TTL answer as misses. */
+  at: number
+}
+
 /** Copilot wire adapter: one instance serves the `copilot` provider route. */
 export class CopilotAdapter extends LlmAdapter {
   private readonly catalog: ModelCatalogCache
   /**
    * [2026-08-23]-[a reasoning model continuing a tool chain must get its
    * reasoning back or it restarts from scratch every tool round trip; the
-   * blobs live in ADAPTER memory because dsh-llm's reasoning ContentBlock is
-   * a closed shape that cannot carry them through the harness]-[stateless
-   * replay degrades to the old behavior once entries are evicted]
+   * items live in ADAPTER memory because dsh-llm's reasoning ContentBlock is
+   * a closed shape that cannot carry them through the harness]-[entries are
+   * namespaced per ACCOUNT × CONVERSATION × MODEL, idle out via a sliding
+   * TTL, and the whole store is dropped on auth transitions, so replay
+   * degrades to the old behavior instead of leaking across contexts]
    */
-  private readonly reasoningByCall = new Map<string, { items: string[] }>()
-  /** Entry cap for {@link reasoningByCall}; see {@link captureReasoning}. */
-  private static readonly REASONING_REPLAY_LIMIT = 64
+  private readonly replayByScope = new Map<string, Map<string, ReasoningReplayEntry>>()
+  /** Call-id entries kept per scope; see {@link captureReasoning}. */
+  private static readonly REPLAY_CALL_LIMIT = 64
+  /** Conversation scopes kept at once; bounds memory when many sessions interleave. */
+  private static readonly REPLAY_SCOPE_LIMIT = 32
+  /** How long a captured entry stays replayable; tool round trips take minutes, not hours. */
+  private static readonly REPLAY_TTL_MS = 30 * 60_000
 
   constructor(private readonly options: CopilotAdapterOptions) {
     super()
@@ -670,21 +707,103 @@ export class CopilotAdapter extends LlmAdapter {
       : { id: configured.id, name: configured.name ?? configured.id, copilotWire: configured.wire }
   }
 
-  /** Store one response's encrypted reasoning behind every call id it produced. */
-  private captureReasoning(callIds: readonly string[], encrypted: readonly string[]): void {
-    // All calls of one response share ONE entry object: toResponsesInput
-    // dedupes replays by array reference, so parallel calls replay the blobs
-    // once instead of once per call.
-    const entry = { items: [...encrypted] }
-    for (const callId of callIds) this.reasoningByCall.set(callId, entry)
+  /**
+   * The replay scope isolating one ACCOUNT × CONVERSATION × MODEL. The
+   * account identity is the session's long-lived GitHub token (stable across
+   * Copilot-token refreshes, different per GitHub login); the conversation is
+   * the loop-stamped `sessionId`, falling back to the first message's id
+   * when a hand-built request carries no session stamp; the model separates
+   * wire families. A call id captured in one scope is invisible to every
+   * other scope, so reused ids cannot leak reasoning across accounts,
+   * conversations, or models.
+   */
+  private replayScope(tokenKey: string, options: GenerateOptions): string {
+    const conversation = options.sessionId !== undefined
+      ? `session:${String(options.sessionId)}`
+      : options.messages[0] !== undefined
+        ? `anchor:${String(options.messages[0].id)}`
+        : 'conversation:none'
+    return `${tokenKey}\u0000${conversation}\u0000${options.model}`
+  }
+
+  /**
+   * Store one response's completed reasoning items behind every call id it
+   * produced, inside one replay scope. Retention: a CONSUMED entry is kept —
+   * every later round of the same conversation replays ALL its earlier
+   * function_calls — until it idles out of the TTL (see {@link replayFor})
+   * or the per-scope entry cap evicts it oldest-first. All calls of one
+   * response share ONE entry object: toResponsesInput dedupes replays by
+   * array reference, so parallel calls replay the items once instead of once
+   * per call.
+   */
+  private captureReasoning(
+    scope: string,
+    callIds: readonly string[],
+    items: readonly ReasoningReplayItem[],
+  ): void {
+    let entries = this.replayByScope.get(scope)
+    if (entries === undefined) {
+      entries = new Map<string, ReasoningReplayEntry>()
+      this.replayByScope.set(scope, entries)
+    } else {
+      // Refresh the scope's recency so an active conversation is never the
+      // scope-cap eviction victim.
+      this.replayByScope.delete(scope)
+      this.replayByScope.set(scope, entries)
+    }
+    const now = Date.now()
+    for (const [callId, entry] of entries) {
+      if (now - entry.at >= CopilotAdapter.REPLAY_TTL_MS) entries.delete(callId)
+    }
+    const entry: ReasoningReplayEntry = { items: [...items], at: now }
+    for (const callId of callIds) entries.set(callId, entry)
     // Blobs reach tens of kilobytes; cap the ENTRY count and evict the oldest
     // by insertion order rather than tracking bytes — eviction merely degrades
     // ancient calls to the pre-capture behavior.
-    while (this.reasoningByCall.size > CopilotAdapter.REASONING_REPLAY_LIMIT) {
-      const oldest = this.reasoningByCall.keys().next().value
+    while (entries.size > CopilotAdapter.REPLAY_CALL_LIMIT) {
+      const oldest = entries.keys().next().value
       if (oldest === undefined) break
-      this.reasoningByCall.delete(oldest)
+      entries.delete(oldest)
     }
+    while (this.replayByScope.size > CopilotAdapter.REPLAY_SCOPE_LIMIT) {
+      const oldest = this.replayByScope.keys().next().value
+      if (oldest === undefined) break
+      this.replayByScope.delete(oldest)
+    }
+  }
+
+  /**
+   * The replay items for one call id in one scope, when still fresh. The TTL
+   * bounds IDLE time, not total age: a hit refreshes the entry (and its
+   * eviction recency), so an ongoing conversation keeps its chain alive
+   * while a conversation that stopped asking forgets within the TTL. An
+   * absent or aged-out entry answers `undefined` — the no-replay
+   * degradation, never an error.
+   */
+  private replayFor(scope: string, callId: string): readonly ReasoningReplayItem[] | undefined {
+    const entries = this.replayByScope.get(scope)
+    const entry = entries?.get(callId)
+    if (entries === undefined || entry === undefined) return undefined
+    const now = Date.now()
+    if (now - entry.at >= CopilotAdapter.REPLAY_TTL_MS) return undefined
+    entry.at = now
+    entries.delete(callId)
+    entries.set(callId, entry)
+    this.replayByScope.delete(scope)
+    this.replayByScope.set(scope, entries)
+    return entry.items
+  }
+
+  /**
+   * Drop every captured replay entry. Lookup correctness never depends on
+   * the call — the scope already carries the account identity — but the host
+   * wiring invokes this on every copilot auth transition (login, logout,
+   * credential death) so a switched account's memory never holds the
+   * previous account's encrypted reasoning at all; conversation teardown is
+   * bounded by the TTL and the caps.
+   */
+  clearReplayState(): void {
+    this.replayByScope.clear()
   }
 
   override async resolveModel(provider: string, model: string): Promise<LlmResolvedModelInfo> {
@@ -719,7 +838,11 @@ export class CopilotAdapter extends LlmAdapter {
         options,
       )
       let session = await this.options.tokens.session()
-      let response = await this.request(options, session, watchdog.signal, wire)
+      // Replay scope: account identity × conversation × model (see
+      // replayScope); a Copilot-token refresh preserves the GitHub token, so
+      // the 401 retry below reuses it too.
+      const scope = this.replayScope(session.refreshToken, options)
+      let response = await this.request(options, session, watchdog.signal, wire, scope)
       if (response.status === 401) {
         // One forced refresh + retry on an unexpired-but-rejected token. The
         // editor version is force-refreshed too: a 401 `IDE token expired`
@@ -727,7 +850,7 @@ export class CopilotAdapter extends LlmAdapter {
         // Editor-Version header fixes that (a new token does not).
         await latestVsCodeVersion(this.options.fetchFn ?? fetch, true)
         session = await this.options.tokens.session(true)
-        response = await this.request(options, session, watchdog.signal, wire)
+        response = await this.request(options, session, watchdog.signal, wire, scope)
       }
       if (!response.ok) throw await httpLlmError(response, 'copilot API')
       if (response.body === null) {
@@ -735,9 +858,9 @@ export class CopilotAdapter extends LlmAdapter {
       }
       const pulse = (): void => { watchdog.pulse() }
       if (wire === 'responses') {
-        // The normalizer doubles as the capture point for encrypted reasoning.
-        const normalizer = new CopilotResponsesItemNormalizer((callIds, encrypted) => {
-          this.captureReasoning(callIds, encrypted)
+        // The normalizer doubles as the capture point for completed reasoning.
+        const normalizer = new CopilotResponsesItemNormalizer((callIds, items) => {
+          this.captureReasoning(scope, callIds, items)
         })
         yield* streamResponses(response.body, pulse, event => normalizer.push(event))
       } else {
@@ -755,6 +878,7 @@ export class CopilotAdapter extends LlmAdapter {
     session: CopilotSession,
     signal: AbortSignal,
     wire: CopilotWire,
+    replayScopeKey: string,
   ): Promise<Response> {
     const messages = await resolveImages(options.messages, this.options.resolveAttachments?.(), signal)
     const hasVision = messages.some(message => message.content.some(block => block.type === 'image'))
@@ -762,8 +886,8 @@ export class CopilotAdapter extends LlmAdapter {
       ? copilotResponsesRequestBody(options, toResponsesInput(
         messages,
         options.system,
-        // Captured encrypted reasoning replays ahead of its tool call.
-        callId => this.reasoningByCall.get(callId)?.items,
+        // Captured completed reasoning replays ahead of its tool call.
+        callId => this.replayFor(replayScopeKey, callId),
       ))
       : copilotChatRequestBody(options, toChatMessages(messages, options.system))
     return fetch(wire === 'responses' ? COPILOT_RESPONSES_URL : COPILOT_API_URL, {

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -461,6 +461,10 @@ export function copilotResponsesRequestBody(
     ...options.reasoningEffort !== undefined
       ? { reasoning: { effort: String(options.reasoningEffort) } }
       : {},
+    // [2026-08-23]-[a reasoning model continuing a tool chain must replay its
+    // encrypted reasoning on the next request, and the blobs only arrive when
+    // asked for; for non-reasoning models the include is a no-op]
+    include: ['reasoning.encrypted_content'],
     stream: true,
   }
 }
@@ -486,6 +490,17 @@ export function copilotResponsesRequestBody(
 export class CopilotResponsesItemNormalizer {
   private adds = 0
   private lastKey = 'copilot-item-0'
+  /** Call ids and encrypted reasoning blobs collected for the open response. */
+  private capturedCallIds: string[] = []
+  private capturedEncrypted: string[] = []
+
+  /**
+   * @param onCaptured - fired at each `response.completed` that produced BOTH
+   *   function calls and encrypted reasoning, receiving the response's call
+   *   ids and encrypted blobs so the adapter can replay them on the next
+   *   request.
+   */
+  constructor(private readonly onCaptured?: (callIds: string[], encrypted: string[]) => void) {}
 
   /**
    * [2026-08-23]-[a single arrival-order ordinal mis-buckets every event after
@@ -512,18 +527,36 @@ export class CopilotResponsesItemNormalizer {
         ? `copilot-item-${String(event.output_index)}`
         : `copilot-item-${String(this.adds)}`
       this.lastKey = key
-      return event.item === undefined
+      const item = event.item
+      if (item?.type === 'function_call' && typeof item.call_id === 'string' && item.call_id.length > 0) {
+        this.capturedCallIds.push(item.call_id)
+      }
+      return item === undefined
         ? event
-        : { ...event, item: { ...event.item, id: key } }
+        : { ...event, item: { ...item, id: key } }
     }
-    const key = this.keyFor(event)
     if (event.type === 'response.output_item.done') {
-      return event.item === undefined
+      const item = event.item
+      if (item?.type === 'reasoning'
+        && typeof item.encrypted_content === 'string' && item.encrypted_content.length > 0) {
+        this.capturedEncrypted.push(item.encrypted_content)
+      }
+      return item === undefined
         ? event
-        : { ...event, item: { ...event.item, id: key } }
+        : { ...event, item: { ...item, id: this.keyFor(event) } }
+    }
+    if (event.type === 'response.completed') {
+      // Both sides present is the only replayable response; clear either way —
+      // one SSE stream may carry multiple responses.
+      if (this.capturedCallIds.length > 0 && this.capturedEncrypted.length > 0) {
+        this.onCaptured?.(this.capturedCallIds, this.capturedEncrypted)
+      }
+      this.capturedCallIds = []
+      this.capturedEncrypted = []
+      return event
     }
     if (event.item_id === undefined) return event
-    return { ...event, item_id: key }
+    return { ...event, item_id: this.keyFor(event) }
   }
 }
 
@@ -547,6 +580,16 @@ export interface CopilotAdapterOptions {
 /** Copilot wire adapter: one instance serves the `copilot` provider route. */
 export class CopilotAdapter extends LlmAdapter {
   private readonly catalog: ModelCatalogCache
+  /**
+   * [2026-08-23]-[a reasoning model continuing a tool chain must get its
+   * reasoning back or it restarts from scratch every tool round trip; the
+   * blobs live in ADAPTER memory because dsh-llm's reasoning ContentBlock is
+   * a closed shape that cannot carry them through the harness]-[stateless
+   * replay degrades to the old behavior once entries are evicted]
+   */
+  private readonly reasoningByCall = new Map<string, { items: string[] }>()
+  /** Entry cap for {@link reasoningByCall}; see {@link captureReasoning}. */
+  private static readonly REASONING_REPLAY_LIMIT = 64
 
   constructor(private readonly options: CopilotAdapterOptions) {
     super()
@@ -627,6 +670,23 @@ export class CopilotAdapter extends LlmAdapter {
       : { id: configured.id, name: configured.name ?? configured.id, copilotWire: configured.wire }
   }
 
+  /** Store one response's encrypted reasoning behind every call id it produced. */
+  private captureReasoning(callIds: readonly string[], encrypted: readonly string[]): void {
+    // All calls of one response share ONE entry object: toResponsesInput
+    // dedupes replays by array reference, so parallel calls replay the blobs
+    // once instead of once per call.
+    const entry = { items: [...encrypted] }
+    for (const callId of callIds) this.reasoningByCall.set(callId, entry)
+    // Blobs reach tens of kilobytes; cap the ENTRY count and evict the oldest
+    // by insertion order rather than tracking bytes — eviction merely degrades
+    // ancient calls to the pre-capture behavior.
+    while (this.reasoningByCall.size > CopilotAdapter.REASONING_REPLAY_LIMIT) {
+      const oldest = this.reasoningByCall.keys().next().value
+      if (oldest === undefined) break
+      this.reasoningByCall.delete(oldest)
+    }
+  }
+
   override async resolveModel(provider: string, model: string): Promise<LlmResolvedModelInfo> {
     const discovered = await this.discovered(model)
     const configured = this.options.models.find(entry => entry.id === model)
@@ -675,7 +735,10 @@ export class CopilotAdapter extends LlmAdapter {
       }
       const pulse = (): void => { watchdog.pulse() }
       if (wire === 'responses') {
-        const normalizer = new CopilotResponsesItemNormalizer()
+        // The normalizer doubles as the capture point for encrypted reasoning.
+        const normalizer = new CopilotResponsesItemNormalizer((callIds, encrypted) => {
+          this.captureReasoning(callIds, encrypted)
+        })
         yield* streamResponses(response.body, pulse, event => normalizer.push(event))
       } else {
         yield* streamChatCompletions(response.body, pulse)
@@ -696,7 +759,12 @@ export class CopilotAdapter extends LlmAdapter {
     const messages = await resolveImages(options.messages, this.options.resolveAttachments?.(), signal)
     const hasVision = messages.some(message => message.content.some(block => block.type === 'image'))
     const body = wire === 'responses'
-      ? copilotResponsesRequestBody(options, toResponsesInput(messages, options.system))
+      ? copilotResponsesRequestBody(options, toResponsesInput(
+        messages,
+        options.system,
+        // Captured encrypted reasoning replays ahead of its tool call.
+        callId => this.reasoningByCall.get(callId)?.items,
+      ))
       : copilotChatRequestBody(options, toChatMessages(messages, options.system))
     return fetch(wire === 'responses' ? COPILOT_RESPONSES_URL : COPILOT_API_URL, {
       method: 'POST',

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -613,6 +613,20 @@ export class CopilotAdapter extends LlmAdapter {
     return models?.find(entry => entry.id === model)
   }
 
+  /**
+   * [2026-08-23]-[a manually configured responses-only model combined with
+   * `discovery:false` left discovered() undefined, so copilotRequestWire
+   * silently defaulted to /chat/completions and the request 404/400'd at the
+   * gateway; an explicit config wire must win over catalog inference]-[config
+   * `models[].wire` now routes the request even without discovery]
+   */
+  private configuredWireEntry(model: string): DiscoveredModel | undefined {
+    const configured = this.options.models.find(entry => entry.id === model)
+    return configured?.wire === undefined
+      ? undefined
+      : { id: configured.id, name: configured.name ?? configured.id, copilotWire: configured.wire }
+  }
+
   override async resolveModel(provider: string, model: string): Promise<LlmResolvedModelInfo> {
     const discovered = await this.discovered(model)
     const configured = this.options.models.find(entry => entry.id === model)
@@ -639,7 +653,11 @@ export class CopilotAdapter extends LlmAdapter {
       // families (gpt-5.5/5.6, …) reject /chat/completions outright, and
       // dual-protocol models reroute there once the request combines function
       // tools with a reasoning effort (gpt-5.4 400s on the chat wire then).
-      const wire = copilotRequestWire(await this.discovered(options.model), options)
+      // A configured `wire` outranks the catalog (see configuredWireEntry).
+      const wire = copilotRequestWire(
+        this.configuredWireEntry(options.model) ?? await this.discovered(options.model),
+        options,
+      )
       let session = await this.options.tokens.session()
       let response = await this.request(options, session, watchdog.signal, wire)
       if (response.status === 401) {

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -1,8 +1,11 @@
 /**
  * GitHub Copilot subscription provider: OAuth device-authorization flow with
  * the VS Code Copilot Chat client id, a GitHub-token → Copilot-token exchange
- * against `copilot_internal/v2/token`, and streaming against the
- * OpenAI-compatible chat completions endpoint (stream-only upstream).
+ * against `copilot_internal/v2/token`, and streaming against two upstream
+ * protocols chosen per model: the OpenAI-compatible chat completions endpoint
+ * for models whose catalog entry lists `/chat/completions`, and the Responses
+ * endpoint for the newer model families (gpt-5.5/5.6, …) that only list
+ * `/responses`. Both upstreams are stream-only.
  *
  * Two token generations are in play: the long-lived GitHub OAuth token (kept
  * as the session's `refreshToken`) and the ~30-minute Copilot API token it
@@ -28,6 +31,8 @@ import {
   toChatMessages,
   toChatTools,
 } from '../translate/chat-completions.js'
+import { streamResponses, toResponsesInput, toResponsesTools } from '../translate/responses.js'
+import type { ResponsesRequestInput, ResponsesStreamEvent } from '../translate/responses.js'
 import {
   httpLlmError,
   idleWatchdog,
@@ -55,6 +60,8 @@ export const COPILOT_DEVICE_TOKEN_URL = 'https://github.com/login/oauth/access_t
 export const COPILOT_TOKEN_URL = 'https://api.github.com/copilot_internal/v2/token'
 export const GITHUB_USER_URL = 'https://api.github.com/user'
 export const COPILOT_API_URL = 'https://api.githubcopilot.com/chat/completions'
+/** Responses endpoint for models whose catalog entry only lists `/responses`. */
+export const COPILOT_RESPONSES_URL = 'https://api.githubcopilot.com/responses'
 export const COPILOT_MODELS_URL = 'https://api.githubcopilot.com/models'
 const COPILOT_SCOPE = 'read:user'
 const COPILOT_CONTEXT_WINDOW = 128_000
@@ -265,10 +272,13 @@ interface CopilotWireModel {
 }
 
 /**
- * Fetch the live Copilot model list. Models hidden from the picker, disabled
- * by policy, or unable to speak /chat/completions are excluded — this adapter
- * only speaks that one protocol. Vision support from the catalog becomes the
- * model's input modalities.
+ * Fetch the live Copilot model list. Models hidden from the picker or
+ * disabled by policy are excluded, as are models able to speak neither
+ * protocol this adapter knows: an entry listing `/chat/completions` speaks
+ * the chat wire, one listing only `/responses` (the newer GPT families,
+ * e.g. gpt-5.6) speaks the Responses wire, and the choice is recorded on the
+ * discovered entry so requests pick the matching endpoint. Vision support
+ * from the catalog becomes the model's input modalities.
  * @param session - the stored session (used as-is; never refreshed here).
  * @param fetchFn - fetch implementation (injectable for tests).
  * @returns discovered chat models in endpoint order.
@@ -292,8 +302,12 @@ export async function fetchCopilotModels(
   for (const entry of payload.data) {
     if (typeof entry.id !== 'string' || entry.id.length === 0 || seen.has(entry.id)) continue
     if (entry.model_picker_enabled !== true || entry.policy?.state === 'disabled') continue
-    if (Array.isArray(entry.supported_endpoints)
-      && !entry.supported_endpoints.includes('/chat/completions')) continue
+    let wire: 'chat-completions' | 'responses' | undefined
+    if (Array.isArray(entry.supported_endpoints)) {
+      if (entry.supported_endpoints.includes('/chat/completions')) wire = 'chat-completions'
+      else if (entry.supported_endpoints.includes('/responses')) wire = 'responses'
+      else continue
+    }
     seen.add(entry.id)
     discovered.push({
       id: entry.id,
@@ -303,6 +317,7 @@ export async function fetchCopilotModels(
         ? { contextWindow: entry.capabilities.limits.max_context_window_tokens }
         : {},
       inputModalities: entry.capabilities?.supports?.vision === true ? ['text', 'image'] : ['text'],
+      ...wire === undefined ? {} : { copilotWire: wire },
     })
   }
   // An empty catalog from a 200 response is treated as a discovery failure so
@@ -310,6 +325,111 @@ export async function fetchCopilotModels(
   // the picker.
   if (discovered.length === 0) throw new Error('copilot models endpoint returned an empty catalog')
   return discovered
+}
+
+/** Which upstream protocol one Copilot model speaks. */
+export type CopilotWire = 'chat-completions' | 'responses'
+
+/**
+ * The wire protocol for one model: the discovered catalog entry's recorded
+ * choice, defaulting to chat completions for unknown models (static-catalog
+ * and no-discovery configurations, and models listing both endpoints).
+ * @param entry - the discovered catalog entry, when known.
+ * @returns the protocol the request for this model must speak.
+ */
+export function copilotWireFor(entry: DiscoveredModel | undefined): CopilotWire {
+  return entry?.copilotWire === 'responses' ? 'responses' : 'chat-completions'
+}
+
+/**
+ * The chat completions request body for one generation. The output cap rides
+ * `max_completion_tokens` — the newer OpenAI-family models on Copilot reject
+ * the legacy `max_tokens` parameter outright (HTTP 400 "Unsupported
+ * parameter"), and the rest of the catalog accepts the new spelling.
+ * @param options - the harness generate options.
+ * @param messages - translated wire messages (images pre-resolved).
+ * @returns the JSON body.
+ */
+export function copilotChatRequestBody(
+  options: GenerateOptions,
+  messages: Record<string, unknown>[],
+): Record<string, unknown> {
+  return {
+    model: options.model,
+    messages,
+    ...options.tools !== undefined && options.tools.length > 0
+      ? { tools: toChatTools(options.tools), tool_choice: 'auto' }
+      : {},
+    ...options.maxTokens !== undefined ? { max_completion_tokens: options.maxTokens } : {},
+    // The upstream is stream-only; usage arrives on the terminal chunk.
+    stream: true,
+    stream_options: { include_usage: true },
+  }
+}
+
+/**
+ * The Responses request body for one generation (the wire the `/responses`-
+ * only model families speak). Usage arrives on `response.completed`.
+ * @param options - the harness generate options.
+ * @param resolved - translated instructions + input (images pre-resolved).
+ * @returns the JSON body.
+ */
+export function copilotResponsesRequestBody(
+  options: GenerateOptions,
+  resolved: ResponsesRequestInput,
+): Record<string, unknown> {
+  return {
+    model: options.model,
+    ...resolved.instructions !== undefined ? { instructions: resolved.instructions } : {},
+    input: resolved.input,
+    ...options.tools !== undefined && options.tools.length > 0
+      ? { tools: toResponsesTools(options.tools), tool_choice: 'auto' }
+      : {},
+    ...options.maxTokens !== undefined ? { max_output_tokens: options.maxTokens } : {},
+    stream: true,
+  }
+}
+
+/**
+ * Rewrite Copilot's Responses-gateway item ids into stable per-item keys.
+ * Unlike chatgpt.com's Responses backend, the Copilot gateway mints a FRESH
+ * opaque `item.id`/`item_id` on every event of one response (the `added`,
+ * each delta, and the `done` all differ), which defeats id-keyed block
+ * assembly in the shared translator: text fragments would each open their
+ * own block, `done` would synthesize duplicates, and a function call whose
+ * arguments arrive whole only on `done` (the deltas carry empty strings)
+ * would close empty. Events of one item are contiguous on the wire, so the
+ * item's ordinal — assigned at `output_item.added` and reused until the next
+ * one — is a faithful stable key. Function-call identity additionally rides
+ * the gateway-stable `call_id`.
+ */
+export class CopilotResponsesItemNormalizer {
+  private ordinal = 0
+
+  private get key(): string {
+    return `copilot-item-${String(this.ordinal)}`
+  }
+
+  /**
+   * Rewrite one parsed Responses event.
+   * @param event - the event as parsed off the wire.
+   * @returns the event with a stable item key.
+   */
+  push(event: ResponsesStreamEvent): ResponsesStreamEvent {
+    if (event.type === 'response.output_item.added') {
+      this.ordinal += 1
+      return event.item === undefined
+        ? event
+        : { ...event, item: { ...event.item, id: this.key } }
+    }
+    if (event.type === 'response.output_item.done') {
+      return event.item === undefined
+        ? event
+        : { ...event, item: { ...event.item, id: this.key } }
+    }
+    if (event.item_id === undefined) return event
+    return { ...event, item_id: this.key }
+  }
 }
 
 /** Constructor dependencies for {@link CopilotAdapter}. */
@@ -415,8 +535,11 @@ export class CopilotAdapter extends LlmAdapter {
   async *stream(options: GenerateOptions): AsyncIterable<StreamChunk> {
     const watchdog = idleWatchdog(options.signal, this.options.streamIdleTimeoutMs)
     try {
+      // The discovered catalog decides the protocol: `/responses`-only model
+      // families (gpt-5.5/5.6, …) reject /chat/completions outright.
+      const wire = copilotWireFor(await this.discovered(options.model))
       let session = await this.options.tokens.session()
-      let response = await this.request(options, session, watchdog.signal)
+      let response = await this.request(options, session, watchdog.signal, wire)
       if (response.status === 401) {
         // One forced refresh + retry on an unexpired-but-rejected token. The
         // editor version is force-refreshed too: a 401 `IDE token expired`
@@ -424,13 +547,19 @@ export class CopilotAdapter extends LlmAdapter {
         // Editor-Version header fixes that (a new token does not).
         await latestVsCodeVersion(this.options.fetchFn ?? fetch, true)
         session = await this.options.tokens.session(true)
-        response = await this.request(options, session, watchdog.signal)
+        response = await this.request(options, session, watchdog.signal, wire)
       }
       if (!response.ok) throw await httpLlmError(response, 'copilot API')
       if (response.body === null) {
         throw new LlmError('copilot API returned no response body', EMPTY_RESPONSE_CODE)
       }
-      yield* streamChatCompletions(response.body, () => { watchdog.pulse() })
+      const pulse = (): void => { watchdog.pulse() }
+      if (wire === 'responses') {
+        const normalizer = new CopilotResponsesItemNormalizer()
+        yield* streamResponses(response.body, pulse, event => normalizer.push(event))
+      } else {
+        yield* streamChatCompletions(response.body, pulse)
+      }
     } catch (error: unknown) {
       throw mapFetchFailure('copilot API', error, watchdog, options.signal)
     } finally {
@@ -438,21 +567,18 @@ export class CopilotAdapter extends LlmAdapter {
     }
   }
 
-  private async request(options: GenerateOptions, session: CopilotSession, signal: AbortSignal): Promise<Response> {
+  private async request(
+    options: GenerateOptions,
+    session: CopilotSession,
+    signal: AbortSignal,
+    wire: CopilotWire,
+  ): Promise<Response> {
     const messages = await resolveImages(options.messages, this.options.resolveAttachments?.(), signal)
     const hasVision = messages.some(message => message.content.some(block => block.type === 'image'))
-    const body = {
-      model: options.model,
-      messages: toChatMessages(messages, options.system),
-      ...options.tools !== undefined && options.tools.length > 0
-        ? { tools: toChatTools(options.tools), tool_choice: 'auto' }
-        : {},
-      ...options.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {},
-      // The upstream is stream-only; usage arrives on the terminal chunk.
-      stream: true,
-      stream_options: { include_usage: true },
-    }
-    return fetch(COPILOT_API_URL, {
+    const body = wire === 'responses'
+      ? copilotResponsesRequestBody(options, toResponsesInput(messages, options.system))
+      : copilotChatRequestBody(options, toChatMessages(messages, options.system))
+    return fetch(wire === 'responses' ? COPILOT_RESPONSES_URL : COPILOT_API_URL, {
       method: 'POST',
       headers: {
         'authorization': `Bearer ${session.accessToken}`,

--- a/src/translate/chat-completions.ts
+++ b/src/translate/chat-completions.ts
@@ -144,7 +144,10 @@ export interface ChatCompletionsStreamEvent {
     index?: number
     delta?: {
       content?: string | null
+      role?: string
       reasoning_content?: string | null
+      /** Copilot's Gemini models stream thinking as `reasoning_text`. */
+      reasoning_text?: string | null
       tool_calls?: {
         index?: number
         id?: string
@@ -211,9 +214,15 @@ function closeBlock(block: OpenBlock): ContentBlock {
  * Push-model chat completions SSE translator: feed each parsed chunk object
  * to {@link push} and collect the emitted harness StreamChunks. The terminal
  * `finish_reason` chunk closes every block but only ARMS the finish chunk —
- * the usage-only final chunk (stream_options.include_usage) still follows, and
- * usage must precede the terminal finish. `flush()` emits whatever remains
- * when the stream's `[DONE]` (or EOF) arrives.
+ * usage must precede the terminal finish, and where usage lives differs by
+ * upstream: OpenAI-style streams send a trailing usage-only chunk
+ * (stream_options.include_usage), while Copilot's Gemini models attach a
+ * (zero) usage object to EVERY chunk and fold the real usage into the
+ * finish chunk itself. A chunk therefore never early-returns on `usage`
+ * alone: its deltas are always processed, and the terminal pair is drained
+ * when the finish is armed and usage arrived (or when a usage-only chunk
+ * follows an armed finish). `flush()` emits whatever remains when the
+ * stream's `[DONE]` (or EOF) arrives.
  */
 export class ChatCompletionsStreamTranslator {
   /** Text/reasoning blocks keyed by kind; tool calls keyed by their wire index. */
@@ -301,12 +310,9 @@ export class ChatCompletionsStreamTranslator {
   push(event: ChatCompletionsStreamEvent): StreamChunk[] {
     if (this.terminated) return []
     const chunks: StreamChunk[] = []
-    if (event.usage !== undefined && event.usage !== null) {
-      this.pendingUsage = event.usage
-      // A usage-only chunk arrives after the finish-reason chunk; flush both.
-      this.drainTerminal(chunks)
-      return chunks
-    }
+    const usage = event.usage
+    const hasUsage = usage !== undefined && usage !== null
+    if (hasUsage) this.pendingUsage = usage
     const choice = event.choices?.[0]
     const delta = choice?.delta
     if (delta !== undefined) {
@@ -315,10 +321,13 @@ export class ChatCompletionsStreamTranslator {
         block.text += delta.content
         chunks.push({ type: 'text-delta', index: block.index, text: delta.content })
       }
-      if (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0) {
+      const reasoning = typeof delta.reasoning_content === 'string' ? delta.reasoning_content
+        : typeof delta.reasoning_text === 'string' ? delta.reasoning_text
+        : undefined
+      if (reasoning !== undefined && reasoning.length > 0) {
         const block = this.blocks.get('reasoning') ?? this.open('reasoning', 'reasoning', chunks)
-        block.text += delta.reasoning_content
-        chunks.push({ type: 'reasoning-delta', index: block.index, text: delta.reasoning_content })
+        block.text += reasoning
+        chunks.push({ type: 'reasoning-delta', index: block.index, text: reasoning })
       }
       for (const call of delta.tool_calls ?? []) {
         const key = `call:${String(call.index ?? 0)}`
@@ -347,10 +356,20 @@ export class ChatCompletionsStreamTranslator {
     }
     if (choice?.finish_reason !== undefined && choice.finish_reason !== null) {
       this.closeAll(chunks)
-      // Only arm: the usage-only final chunk (include_usage) still follows,
-      // and usage must be emitted before the terminal finish. The usage chunk
-      // or flush() drains both.
-      this.armedFinish = this.finishChunk(choice.finish_reason)
+      // Only arm: usage must be emitted before the terminal finish, and it
+      // may still arrive (OpenAI's trailing usage-only chunk) or may have
+      // arrived in this very chunk (Gemini folds it in). The drain below or
+      // flush() releases the pair.
+      if (this.armedFinish === undefined) this.armedFinish = this.finishChunk(choice.finish_reason)
+    }
+    // Drain at the terminal point: this chunk carried usage AND either the
+    // finish is armed (usage + finish pair complete — same chunk for Gemini,
+    // trailing chunk for OpenAI) or the chunk is usage-only (no choices to
+    // process). Mid-stream usage carriers (Gemini's zero-usage deltas) keep
+    // their pendingUsage for a later drain; only the final real usage is
+    // emitted.
+    if (hasUsage && (this.armedFinish !== undefined || choice === undefined)) {
+      this.drainTerminal(chunks)
     }
     return chunks
   }

--- a/src/translate/responses.ts
+++ b/src/translate/responses.ts
@@ -406,11 +406,15 @@ export class ResponsesStreamTranslator {
  * Consume a Responses SSE byte stream and yield harness StreamChunks.
  * @param stream - raw response body.
  * @param onActivity - transport-activity callback for the idle watchdog.
+ * @param transform - optional per-event rewrite applied before translation
+ *   (Copilot's gateway mints a fresh item id per event; the adapter rewrites
+ *   them into stable per-item keys).
  * @returns the chunk stream; throws when the stream ends before `response.completed`.
  */
 export async function* streamResponses(
   stream: ReadableStream<Uint8Array>,
   onActivity?: () => void,
+  transform?: (event: ResponsesStreamEvent) => ResponsesStreamEvent,
 ): AsyncGenerator<StreamChunk> {
   const translator = new ResponsesStreamTranslator()
   for await (const sseEvent of parseSse(stream, onActivity)) {
@@ -420,6 +424,7 @@ export async function* streamResponses(
     } catch {
       throw new LlmError(`malformed SSE payload: ${sseEvent.data.slice(0, 120)}`, 'MALFORMED_RESPONSE')
     }
+    if (transform !== undefined) event = transform(event)
     yield* translator.push(event)
     if (translator.terminated) return
   }

--- a/src/translate/responses.ts
+++ b/src/translate/responses.ts
@@ -40,16 +40,31 @@ function toolResultText(block: ToolResultBlock): string {
 /**
  * Convert harness messages into Responses `instructions` + `input` items.
  * System-role messages become `instructions`; an explicit `system` argument
- * wins over them when both exist. Reasoning blocks are not replayed (v1).
- * Images must arrive pre-resolved ({@link TranslatableMessage}); an unresolved
- * ImageBlock is skipped because its bytes are unreachable here.
+ * wins over them when both exist. Reasoning blocks are never replayed in
+ * their text form: a Responses model continuing past a tool call needs its
+ * reasoning back as the provider's ENCRYPTED blob, so `reasoningFor` may
+ * resolve per-call encrypted payloads, replayed ahead of the matching
+ * function_call item. Images must arrive pre-resolved
+ * ({@link TranslatableMessage}); an unresolved ImageBlock is skipped because
+ * its bytes are unreachable here.
  * @param messages - ordered conversation messages with resolved images.
  * @param system - explicit system prompt, which takes precedence.
+ * @param reasoningFor - resolves one tool call id to the encrypted reasoning
+ *   blobs captured for it, when the adapter kept them.
  * @returns request fields ready to merge into the request body.
  */
-export function toResponsesInput(messages: readonly TranslatableMessage[], system?: string): ResponsesRequestInput {
+export function toResponsesInput(
+  messages: readonly TranslatableMessage[],
+  system?: string,
+  reasoningFor?: (callId: string) => readonly string[] | undefined,
+): ResponsesRequestInput {
   const input: Record<string, unknown>[] = []
   const systemTexts: string[] = []
+  // [2026-08-23]-[reasoning models lose their chain of thought across a tool
+  // round trip unless the encrypted blobs ride back in; dedupe by ARRAY
+  // REFERENCE so parallel calls of one response (which share one array
+  // instance) replay the blobs once, before the first of them]
+  let lastReplay: readonly string[] | undefined
   for (const message of messages) {
     if (message.role === 'system') {
       for (const block of message.content) {
@@ -69,8 +84,13 @@ export function toResponsesInput(messages: readonly TranslatableMessage[], syste
         case 'text':
           content.push({ type: role === 'assistant' ? 'output_text' : 'input_text', text: block.text })
           break
-        case 'tool-call':
+        case 'tool-call': {
           flushMessage()
+          const encrypted = reasoningFor?.(String(block.id))
+          if (encrypted !== undefined && encrypted !== lastReplay) {
+            for (const blob of encrypted) input.push({ type: 'reasoning', encrypted_content: blob })
+            lastReplay = encrypted
+          }
           input.push({
             type: 'function_call',
             call_id: String(block.id),
@@ -78,6 +98,7 @@ export function toResponsesInput(messages: readonly TranslatableMessage[], syste
             arguments: block.arguments,
           })
           break
+        }
         case 'tool-result':
           flushMessage()
           input.push({
@@ -97,7 +118,8 @@ export function toResponsesInput(messages: readonly TranslatableMessage[], syste
           // adapter resolves images before translation, so this is skipped.
           break
         default:
-          // reasoning (not replayed), unknown blocks.
+          // reasoning's text form is not replayed (encrypted replay rides
+          // reasoningFor), unknown blocks.
           break
       }
     }

--- a/src/translate/responses.ts
+++ b/src/translate/responses.ts
@@ -125,6 +125,12 @@ export function toResponsesTools(tools: readonly ToolSchema[]): Record<string, u
 export interface ResponsesStreamEvent {
   type: string
   item_id?: string
+  /**
+   * Position of the event's item in the response's output array. The spec
+   * carries it on output_item/delta events; Copilot's adapter uses it as the
+   * stable item correlator when the gateway mints fresh ids per event.
+   */
+  output_index?: number
   content_index?: number
   summary_index?: number
   delta?: string
@@ -134,6 +140,8 @@ export interface ResponsesStreamEvent {
     call_id?: string
     name?: string
     arguments?: string
+    /** Encrypted reasoning payload, present when the request asked to include it. */
+    encrypted_content?: string
     content?: Array<{ type?: string; text?: string }>
   }
   response?: {

--- a/src/translate/responses.ts
+++ b/src/translate/responses.ts
@@ -32,6 +32,28 @@ export interface ResponsesRequestInput {
   input: Record<string, unknown>[]
 }
 
+/**
+ * One COMPLETED reasoning output item captured off a response, replayed as
+ * the complete item on a later request of the same conversation. The
+ * Responses input schema does not treat a reasoning item's `id` or
+ * `summary` as optional — a bare `{ type, encrypted_content }` is not a
+ * valid input item — so the capture keeps the item's gateway id (as it
+ * arrived on the done event), its summary parts, its status, and the
+ * encrypted payload. `encrypted_content` is the only required field here:
+ * items without one are simply never captured.
+ */
+export interface ReasoningReplayItem {
+  type: 'reasoning'
+  /** The item's gateway id as it arrived on the done event. */
+  id?: string
+  /** Summary parts, passed through when the gateway disclosed them. */
+  summary?: unknown[]
+  /** Item lifecycle status, passed through when present (typically `completed`). */
+  status?: string
+  /** Encrypted reasoning payload; the reason the item is worth replaying. */
+  encrypted_content: string
+}
+
 /** Flatten a tool result's content to plain text for `function_call_output`. */
 function toolResultText(block: ToolResultBlock): string {
   return block.content.map(part => (part.type === 'text' ? part.text : '')).join('')
@@ -42,29 +64,31 @@ function toolResultText(block: ToolResultBlock): string {
  * System-role messages become `instructions`; an explicit `system` argument
  * wins over them when both exist. Reasoning blocks are never replayed in
  * their text form: a Responses model continuing past a tool call needs its
- * reasoning back as the provider's ENCRYPTED blob, so `reasoningFor` may
- * resolve per-call encrypted payloads, replayed ahead of the matching
- * function_call item. Images must arrive pre-resolved
+ * reasoning back as the provider's completed reasoning items (id, summary,
+ * and the ENCRYPTED payload), so `reasoningFor` may resolve per-call
+ * captured items, replayed ahead of the matching function_call item. Images
+ * must arrive pre-resolved
  * ({@link TranslatableMessage}); an unresolved ImageBlock is skipped because
  * its bytes are unreachable here.
  * @param messages - ordered conversation messages with resolved images.
  * @param system - explicit system prompt, which takes precedence.
- * @param reasoningFor - resolves one tool call id to the encrypted reasoning
- *   blobs captured for it, when the adapter kept them.
+ * @param reasoningFor - resolves one tool call id to the COMPLETED reasoning
+ *   items captured for it (id, summary, status, encrypted payload), replayed
+ *   ahead of the matching function_call item, when the adapter kept them.
  * @returns request fields ready to merge into the request body.
  */
 export function toResponsesInput(
   messages: readonly TranslatableMessage[],
   system?: string,
-  reasoningFor?: (callId: string) => readonly string[] | undefined,
+  reasoningFor?: (callId: string) => readonly ReasoningReplayItem[] | undefined,
 ): ResponsesRequestInput {
   const input: Record<string, unknown>[] = []
   const systemTexts: string[] = []
   // [2026-08-23]-[reasoning models lose their chain of thought across a tool
-  // round trip unless the encrypted blobs ride back in; dedupe by ARRAY
-  // REFERENCE so parallel calls of one response (which share one array
-  // instance) replay the blobs once, before the first of them]
-  let lastReplay: readonly string[] | undefined
+  // round trip unless the completed reasoning items ride back in; dedupe by
+  // ARRAY REFERENCE so parallel calls of one response (which share one array
+  // instance) replay the items once, before the first of them]
+  let lastReplay: readonly ReasoningReplayItem[] | undefined
   for (const message of messages) {
     if (message.role === 'system') {
       for (const block of message.content) {
@@ -88,7 +112,15 @@ export function toResponsesInput(
           flushMessage()
           const encrypted = reasoningFor?.(String(block.id))
           if (encrypted !== undefined && encrypted !== lastReplay) {
-            for (const blob of encrypted) input.push({ type: 'reasoning', encrypted_content: blob })
+            for (const item of encrypted) {
+              input.push({
+                type: 'reasoning',
+                ...item.id === undefined ? {} : { id: item.id },
+                ...item.summary === undefined ? {} : { summary: item.summary },
+                ...item.status === undefined ? {} : { status: item.status },
+                encrypted_content: item.encrypted_content,
+              })
+            }
             lastReplay = encrypted
           }
           input.push({
@@ -164,6 +196,10 @@ export interface ResponsesStreamEvent {
     arguments?: string
     /** Encrypted reasoning payload, present when the request asked to include it. */
     encrypted_content?: string
+    /** Summary parts of a completed reasoning item, when the gateway disclosed them. */
+    summary?: unknown[]
+    /** Item lifecycle status (e.g. `completed`), when present. */
+    status?: string
     content?: Array<{ type?: string; text?: string }>
   }
   response?: {

--- a/test/catalog-store.spec.ts
+++ b/test/catalog-store.spec.ts
@@ -85,6 +85,17 @@ test('sanitizeSnapshot drops malformed snapshots wholesale', () => {
   )
   assert.equal(sanitizeSnapshot({ at: 1, models: [{ ...model, inputModalities: [] }] }), undefined)
   assert.equal(sanitizeSnapshot({ at: 1, models: [{ ...model, inputModalities: ['video'] }] }), undefined)
+  // The Copilot wire choice and dual-protocol flag round-trip (a snapshot
+  // losing them would route every restarted model to the chat wire); a
+  // malformed value drops the snapshot.
+  const copilot = sanitizeSnapshot({
+    at: 1,
+    models: [{ ...model, copilotWire: 'responses', copilotResponses: true }],
+  })?.models[0]
+  assert.equal(copilot?.copilotWire, 'responses')
+  assert.equal(copilot?.copilotResponses, true)
+  assert.equal(sanitizeSnapshot({ at: 1, models: [{ ...model, copilotWire: 'grpc' }] }), undefined)
+  assert.equal(sanitizeSnapshot({ at: 1, models: [{ ...model, copilotResponses: 'yes' }] }), undefined)
   for (const malformed of [
     undefined,
     null,

--- a/test/chat-completions.spec.ts
+++ b/test/chat-completions.spec.ts
@@ -194,6 +194,59 @@ test('translator: reasoning_content becomes a reasoning block', () => {
   ])
 })
 
+test('translator: Copilot Gemini streams (usage on every chunk) keep their deltas', () => {
+  // Regression: Copilot's Gemini models attach a zero `usage` object to every
+  // chunk and stream thinking as `reasoning_text`; the real usage rides the
+  // finish chunk itself. The old early-return on usage-bearing chunks
+  // swallowed every delta, leaving an empty response with usage only.
+  const translator = new ChatCompletionsStreamTranslator()
+  const mid = drain(translator, [
+    {
+      choices: [{ index: 0, delta: { content: null, role: 'assistant', reasoning_text: 'greeting…' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+    },
+    {
+      choices: [{ index: 0, delta: { content: 'Hello, how are you today?', role: 'assistant' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+    },
+  ])
+  // The mid-stream zero-usage chunks emit no usage of their own.
+  assert.deepEqual(mid, [
+    { type: 'block-start', index: 0, blockType: 'reasoning' },
+    { type: 'reasoning-delta', index: 0, text: 'greeting…' },
+    { type: 'block-start', index: 1, blockType: 'text' },
+    { type: 'text-delta', index: 1, text: 'Hello, how are you today?' },
+  ])
+  assert.equal(translator.terminated, false)
+  // The finish chunk carries finish_reason AND the real usage together.
+  const terminal = translator.push({
+    choices: [{ index: 0, delta: { content: null, role: 'assistant' }, finish_reason: 'stop' }],
+    usage: {
+      prompt_tokens: 8,
+      completion_tokens: 7,
+      prompt_tokens_details: { cached_tokens: 0 },
+      completion_tokens_details: { reasoning_tokens: 4 },
+    },
+  })
+  assert.deepEqual(terminal, [
+    { type: 'block-end', index: 0, block: { type: 'reasoning', text: 'greeting…' } },
+    { type: 'block-end', index: 1, block: { type: 'text', text: 'Hello, how are you today?' } },
+    { type: 'usage', usage: { inputTokens: 8, outputTokens: 7, cacheReadTokens: 0, reasoningTokens: 4 } },
+    { type: 'finish', reason: { kind: 'stop' } },
+  ])
+  assert.equal(translator.terminated, true)
+})
+
+test('translator: a finish chunk without usage still arms until flush', () => {
+  const translator = new ChatCompletionsStreamTranslator()
+  drain(translator, [
+    { choices: [{ delta: { content: 'hi' } }] },
+    { choices: [{ delta: {}, finish_reason: 'stop' }] },
+  ])
+  // No usage anywhere: [DONE] (flush) releases the finish alone.
+  assert.deepEqual(translator.flush(), [{ type: 'finish', reason: { kind: 'stop' } }])
+})
+
 test('translator: finish reasons map to harness kinds', () => {
   const length = new ChatCompletionsStreamTranslator()
   drain(length, [
@@ -252,6 +305,35 @@ test('streamChatCompletions consumes an SSE stream through [DONE]', async () => 
   assert.deepEqual(chunks.map(chunk => chunk.type), [
     'block-start', 'text-delta', 'block-end', 'usage', 'finish',
   ])
+})
+
+test('streamChatCompletions: a Copilot Gemini SSE stream yields text and terminates', async () => {
+  // Raw shape captured from api.githubcopilot.com with gemini-3.5-flash:
+  // every data frame carries a (zero) usage object; the terminal frame folds
+  // the real usage into the finish chunk; [DONE] follows.
+  const stream = byteStream([
+    frame({
+      choices: [{ index: 0, delta: { content: null, role: 'assistant', reasoning_text: 'greeting…' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+    }),
+    frame({
+      choices: [{ index: 0, delta: { content: 'Hello, how are you today?', role: 'assistant' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+    }),
+    frame({
+      choices: [{ index: 0, delta: { content: null, role: 'assistant' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 8, completion_tokens: 7 },
+    }),
+    'data: [DONE]\n\n',
+  ])
+  const chunks: StreamChunk[] = []
+  for await (const chunk of streamChatCompletions(stream)) chunks.push(chunk)
+  assert.deepEqual(chunks.map(chunk => chunk.type), [
+    'block-start', 'reasoning-delta', 'block-start', 'text-delta',
+    'block-end', 'block-end', 'usage', 'finish',
+  ])
+  const text = chunks.find(chunk => chunk.type === 'text-delta')
+  assert.equal(text?.type === 'text-delta' ? text.text : undefined, 'Hello, how are you today?')
 })
 
 test('streamChatCompletions: a stream without a finish chunk throws STREAM_CLOSED', async () => {

--- a/test/copilot.spec.ts
+++ b/test/copilot.spec.ts
@@ -9,9 +9,15 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { MessageId } from '@deepseek-ai/dsh-llm'
+import type { GenerateOptions } from '@deepseek-ai/dsh-llm'
 import {
   completeCopilotLogin,
   COPILOT_TOKEN_URL,
+  CopilotResponsesItemNormalizer,
+  copilotChatRequestBody,
+  copilotResponsesRequestBody,
+  copilotWireFor,
   exchangeCopilotToken,
   FALLBACK_VSCODE_VERSION,
   GITHUB_USER_URL,
@@ -21,8 +27,10 @@ import {
   VSCODE_RELEASES_URL,
 } from '../src/providers/copilot.js'
 import { OAuthEndpointError } from '../src/providers/common.js'
-import type { FetchFn } from '../src/providers/common.js'
+import type { DiscoveredModel, FetchFn } from '../src/providers/common.js'
 import type { CopilotSession } from '../src/auth/store.js'
+import { streamResponses } from '../src/translate/responses.js'
+import type { ResponsesStreamEvent } from '../src/translate/responses.js'
 
 /** A fetch implementation routing canned responses by URL; records request headers. */
 function fakeFetch(routes: Record<string, { payload: unknown; status?: number } | Error>): {
@@ -139,4 +147,118 @@ test('refreshCopilot re-exchanges and preserves the account', async () => {
   })
   // The refresh exchanges with the GITHUB token, never the stale Copilot one.
   assert.equal(headers(COPILOT_TOKEN_URL)[0].authorization, 'Bearer gh-token')
+})
+
+/** Minimal generate options for the request body builders. */
+const BODY_OPTIONS: GenerateOptions = {
+  provider: 'copilot',
+  model: 'gpt-5.6-sol',
+  messages: [{
+    id: MessageId('m-1'),
+    role: 'user',
+    content: [{ type: 'text', text: 'hi' }],
+    source: { kind: 'user' },
+  }],
+  maxTokens: 16_000,
+}
+
+test('copilotChatRequestBody sends max_completion_tokens, never max_tokens', () => {
+  // gpt-5.4-and-later on Copilot reject the legacy `max_tokens` outright
+  // (HTTP 400 "Unsupported parameter"); the rest of the catalog accepts the
+  // new spelling.
+  const body = copilotChatRequestBody(BODY_OPTIONS, [{ role: 'user', content: 'hi' }])
+  assert.equal(body.max_completion_tokens, 16_000)
+  assert.equal('max_tokens' in body, false)
+  assert.equal(body.stream, true)
+  assert.deepEqual(body.stream_options, { include_usage: true })
+})
+
+test('copilotResponsesRequestBody maps the Responses wire shape', () => {
+  const body = copilotResponsesRequestBody(BODY_OPTIONS, {
+    instructions: 'be terse',
+    input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+  })
+  assert.deepEqual(body, {
+    model: 'gpt-5.6-sol',
+    instructions: 'be terse',
+    input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+    max_output_tokens: 16_000,
+    stream: true,
+  })
+  // No system prompt → no instructions field; tools ride the Responses shape.
+  const { maxTokens: omitted, ...bareOptions } = BODY_OPTIONS
+  const bare = copilotResponsesRequestBody(
+    { ...bareOptions, tools: [{ name: 'bash', description: 'run', parameters: { type: 'object' } }] },
+    { input: [] },
+  )
+  assert.equal('instructions' in bare, false)
+  assert.equal('max_output_tokens' in bare, false)
+  assert.deepEqual(bare.tools, [{ type: 'function', name: 'bash', description: 'run', parameters: { type: 'object' } }])
+  assert.equal(bare.tool_choice, 'auto')
+})
+
+test('copilotWireFor defaults to chat completions unless the catalog says responses', () => {
+  assert.equal(copilotWireFor(undefined), 'chat-completions')
+  const chat: DiscoveredModel = { id: 'gpt-5-mini', name: 'GPT-5 mini', copilotWire: 'chat-completions' }
+  assert.equal(copilotWireFor(chat), 'chat-completions')
+  const responses: DiscoveredModel = { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', copilotWire: 'responses' }
+  assert.equal(copilotWireFor(responses), 'responses')
+  // An entry without the flag (static fallback path) stays on the chat wire.
+  assert.equal(copilotWireFor({ id: 'gpt-4o', name: 'GPT-4o' }), 'chat-completions')
+})
+
+test('CopilotResponsesItemNormalizer folds per-event item ids into one stable key', () => {
+  // Raw shape captured from api.githubcopilot.com/responses with gpt-5.6:
+  // every event of one item carries a DIFFERENT opaque id.
+  const normalizer = new CopilotResponsesItemNormalizer()
+  const rewritten = [
+    { type: 'response.output_item.added', item: { type: 'message', id: 'added-id' } },
+    { type: 'response.output_text.delta', item_id: 'delta-id-1', delta: 'Hi' },
+    { type: 'response.output_text.delta', item_id: 'delta-id-2', delta: ' there' },
+    { type: 'response.output_item.done', item: { type: 'message', id: 'done-id', content: [{ type: 'output_text', text: 'Hi there' }] } },
+  ].map(event => normalizer.push(event as ResponsesStreamEvent))
+  assert.equal(rewritten[0]?.item?.id, 'copilot-item-1')
+  assert.equal(rewritten[1]?.item_id, 'copilot-item-1')
+  assert.equal(rewritten[2]?.item_id, 'copilot-item-1')
+  assert.equal(rewritten[3]?.item?.id, 'copilot-item-1')
+  // The next item gets the next ordinal.
+  const next = normalizer.push({ type: 'response.output_item.added', item: { type: 'function_call', id: 'x', call_id: 'call-1', name: 'bash' } })
+  assert.equal(next.item?.id, 'copilot-item-2')
+})
+
+test('normalized Copilot Responses events assemble text and whole-done tool arguments', async () => {
+  // End-to-end through the shared translator with the normalizer: text
+  // fragments join into one block, and a function call whose argument deltas
+  // are empty (the gateway delivers the arguments whole on done) closes with
+  // the full payload.
+  const normalizer = new CopilotResponsesItemNormalizer()
+  const events: ResponsesStreamEvent[] = [
+    { type: 'response.output_item.added', item: { type: 'message', id: 'a' } },
+    { type: 'response.output_text.delta', item_id: 'd1', delta: 'Hi' },
+    { type: 'response.output_text.delta', item_id: 'd2', delta: '!' },
+    { type: 'response.output_item.done', item: { type: 'message', id: 'b', content: [{ type: 'output_text', text: 'Hi!' }] } },
+    { type: 'response.output_item.added', item: { type: 'function_call', id: 'c', call_id: 'call-9', name: 'bash' } },
+    { type: 'response.function_call_arguments.delta', item_id: 'd3', delta: '' },
+    { type: 'response.output_item.done', item: { type: 'function_call', id: 'e', call_id: 'call-9', name: 'bash', arguments: '{"cmd":"ls"}' } },
+    { type: 'response.completed', response: { usage: { input_tokens: 5, output_tokens: 3 } } },
+  ]
+  const frames = events.map(event => `data: ${JSON.stringify(event)}\n\n`).join('') + 'data: [DONE]\n\n'
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(frames))
+      controller.close()
+    },
+  })
+  const chunks: { type: string; block?: { type: string; name?: string; text?: string; arguments?: string } }[] = []
+  for await (const chunk of streamResponses(stream, undefined, event => normalizer.push(event))) {
+    chunks.push(chunk as { type: string; block?: { type: string; name?: string; text?: string; arguments?: string } })
+  }
+  const blocks = chunks.filter(chunk => chunk.type === 'block-end').map(chunk => chunk.block)
+  assert.equal(blocks.length, 2)
+  assert.deepEqual(blocks[0], { type: 'text', text: 'Hi!' })
+  assert.equal(blocks[1]?.type, 'tool-call')
+  assert.equal(blocks[1]?.name, 'bash')
+  assert.equal(blocks[1]?.arguments, '{"cmd":"ls"}')
+  const finish = chunks.find(chunk => chunk.type === 'finish')
+  assert.equal(finish?.type, 'finish')
 })

--- a/test/copilot.spec.ts
+++ b/test/copilot.spec.ts
@@ -34,7 +34,7 @@ import { OAuthEndpointError, TokenManager, validateModels } from '../src/provide
 import type { DiscoveredModel, FetchFn, ModelEntry } from '../src/providers/common.js'
 import type { CopilotSession } from '../src/auth/store.js'
 import { streamResponses } from '../src/translate/responses.js'
-import type { ResponsesStreamEvent } from '../src/translate/responses.js'
+import type { ReasoningReplayItem, ResponsesStreamEvent } from '../src/translate/responses.js'
 
 /** A fetch implementation routing canned responses by URL; records request headers. */
 function fakeFetch(routes: Record<string, { payload: unknown; status?: number } | Error>): {
@@ -548,16 +548,39 @@ test('a configured wire outranks a discovered chat-wire catalog entry', async ()
   }
 })
 
-test('CopilotResponsesItemNormalizer captures call ids and encrypted reasoning on completion', () => {
-  const captures: { callIds: string[]; encrypted: string[] }[] = []
-  const normalizer = new CopilotResponsesItemNormalizer((callIds, encrypted) => {
-    captures.push({ callIds: [...callIds], encrypted: [...encrypted] })
+test('CopilotResponsesItemNormalizer captures call ids and COMPLETED reasoning items', () => {
+  const captures: { callIds: string[]; items: ReasoningReplayItem[] }[] = []
+  const normalizer = new CopilotResponsesItemNormalizer((callIds, items) => {
+    captures.push({ callIds: [...callIds], items: [...items] })
   })
   normalizer.push({ type: 'response.output_item.added', output_index: 0, item: { type: 'reasoning', id: 'r1' } })
-  normalizer.push({ type: 'response.output_item.done', output_index: 0, item: { type: 'reasoning', id: 'r2', encrypted_content: 'ENC1' } })
+  normalizer.push({
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      type: 'reasoning',
+      id: 'rs_done_1',
+      summary: [{ type: 'summary_text', text: 'listed the directory first' }],
+      status: 'completed',
+      encrypted_content: 'ENC1',
+    },
+  })
   normalizer.push({ type: 'response.output_item.added', output_index: 1, item: { type: 'function_call', id: 'f1', call_id: 'call-7', name: 'bash' } })
   normalizer.push({ type: 'response.completed', response: {} })
-  assert.deepEqual(captures, [{ callIds: ['call-7'], encrypted: ['ENC1'] }])
+  // The capture keeps the COMPLETE done item — original gateway id (not the
+  // stable-key rewrite), summary parts, status, and the encrypted payload —
+  // because the Responses input schema requires id and summary on a
+  // replayed reasoning item, not a bare encrypted blob.
+  assert.deepEqual(captures, [{
+    callIds: ['call-7'],
+    items: [{
+      type: 'reasoning',
+      id: 'rs_done_1',
+      summary: [{ type: 'summary_text', text: 'listed the directory first' }],
+      status: 'completed',
+      encrypted_content: 'ENC1',
+    }],
+  }])
   // Cleared after the fire: a second completed event in the same stream must
   // not re-report the first response's pair.
   normalizer.push({ type: 'response.completed', response: {} })
@@ -566,28 +589,32 @@ test('CopilotResponsesItemNormalizer captures call ids and encrypted reasoning o
 
 test('CopilotResponsesItemNormalizer does not capture without both sides of the pair', () => {
   const captures: unknown[][] = []
-  const normalizer = new CopilotResponsesItemNormalizer((callIds, encrypted) => {
-    captures.push([callIds, encrypted])
+  const normalizer = new CopilotResponsesItemNormalizer((callIds, items) => {
+    captures.push([callIds, items])
   })
-  // A function call with no encrypted reasoning in its response.
+  // A function call with no completed reasoning in its response.
   normalizer.push({ type: 'response.output_item.added', item: { type: 'function_call', id: 'f1', call_id: 'call-7' } })
   normalizer.push({ type: 'response.completed', response: {} })
-  // Encrypted reasoning with no function call in its response.
+  // Completed reasoning with no function call in its response.
   normalizer.push({ type: 'response.output_item.done', item: { type: 'reasoning', id: 'r1', encrypted_content: 'ENC1' } })
   normalizer.push({ type: 'response.completed', response: {} })
-  // Malformed shapes (empty call_id, empty encrypted_content) never collect.
+  // Malformed shapes (empty call_id, empty encrypted_content, missing id)
+  // never collect: an item without its id or blob is not a valid replayable
+  // Responses input item, so it degrades to no replay.
   normalizer.push({ type: 'response.output_item.added', item: { type: 'function_call', id: 'f2', call_id: '' } })
   normalizer.push({ type: 'response.output_item.done', item: { type: 'reasoning', id: 'r2', encrypted_content: '' } })
+  normalizer.push({ type: 'response.output_item.done', item: { type: 'reasoning', encrypted_content: 'ENC_NO_ID' } })
   normalizer.push({ type: 'response.completed', response: {} })
   assert.equal(captures.length, 0)
 })
 
 /**
  * SSE payload for the adapter-level capture tests: the model reasons (the
- * reasoning done carries the encrypted blob when `encrypted` is given) and
- * issues one tool call whose arguments arrive whole on done.
+ * reasoning done carries the COMPLETE item — id, summary, status, and the
+ * encrypted blob — when `encrypted` is given) and issues one tool call whose
+ * arguments arrive whole on done.
  */
-function reasoningToolCallSse(encrypted: string | undefined): string {
+function reasoningToolCallSse(encrypted: string | undefined, callId = 'call_A'): string {
   return sseBody([
     { type: 'response.output_item.added', output_index: 0, item: { type: 'reasoning', id: 'r1' } },
     {
@@ -595,70 +622,242 @@ function reasoningToolCallSse(encrypted: string | undefined): string {
       output_index: 0,
       item: encrypted === undefined
         ? { type: 'reasoning', id: 'r2' }
-        : { type: 'reasoning', id: 'r2', encrypted_content: encrypted },
+        : {
+            type: 'reasoning',
+            id: 'rs_done_1',
+            summary: [{ type: 'summary_text', text: 'planned the ls call' }],
+            status: 'completed',
+            encrypted_content: encrypted,
+          },
     },
-    { type: 'response.output_item.added', output_index: 1, item: { type: 'function_call', id: 'f1', call_id: 'call_A', name: 'bash' } },
+    { type: 'response.output_item.added', output_index: 1, item: { type: 'function_call', id: 'f1', call_id: callId, name: 'bash' } },
     { type: 'response.function_call_arguments.delta', output_index: 1, item_id: 'f2', delta: '' },
-    { type: 'response.output_item.done', output_index: 1, item: { type: 'function_call', id: 'f3', call_id: 'call_A', name: 'bash', arguments: '{"cmd":"ls"}' } },
+    { type: 'response.output_item.done', output_index: 1, item: { type: 'function_call', id: 'f3', call_id: callId, name: 'bash', arguments: '{"cmd":"ls"}' } },
     { type: 'response.completed', response: { usage: { input_tokens: 3, output_tokens: 4 } } },
   ])
 }
 
-/** The conversation handed back for the second request after call_A ran. */
-function toolRoundTripHistory(): GenerateOptions['messages'] {
+/** A second response's SSE: reasoning (ENC2) followed by a call to `call_B`. */
+function secondReasoningToolCallSse(): string {
+  return sseBody([
+    { type: 'response.output_item.added', output_index: 0, item: { type: 'reasoning', id: 'r3' } },
+    {
+      type: 'response.output_item.done',
+      output_index: 0,
+      item: {
+        type: 'reasoning',
+        id: 'rs_done_2',
+        summary: [{ type: 'summary_text', text: 'read the listing' }],
+        status: 'completed',
+        encrypted_content: 'ENC2',
+      },
+    },
+    { type: 'response.output_item.added', output_index: 1, item: { type: 'function_call', id: 'g1', call_id: 'call_B', name: 'grep' } },
+    { type: 'response.function_call_arguments.delta', output_index: 1, item_id: 'g2', delta: '' },
+    { type: 'response.output_item.done', output_index: 1, item: { type: 'function_call', id: 'g3', call_id: 'call_B', name: 'grep', arguments: '{"q":"x"}' } },
+    { type: 'response.completed', response: { usage: { input_tokens: 3, output_tokens: 4 } } },
+  ])
+}
+
+/** The conversation handed back for the second request after the call ran. */
+function toolRoundTripHistory(callId = 'call_A'): GenerateOptions['messages'] {
   return [
     {
       id: MessageId('m-a'),
       role: 'assistant',
       content: [
         { type: 'reasoning', text: 'thinking' },
-        { type: 'tool-call', id: CallId('call_A'), name: 'bash', arguments: '{"cmd":"ls"}' },
+        { type: 'tool-call', id: CallId(callId), name: 'bash', arguments: '{"cmd":"ls"}' },
       ],
       source: { kind: 'model', provider: 'copilot', model: 'gpt-5.6-sol' },
     },
     {
       id: MessageId('m-b'),
       role: 'user',
-      content: [{ type: 'tool-result', toolCallId: CallId('call_A'), content: [{ type: 'text', text: 'file-a' }] }],
-      source: { kind: 'tool', callId: CallId('call_A') },
+      content: [{ type: 'tool-result', toolCallId: CallId(callId), content: [{ type: 'text', text: 'file-a' }] }],
+      source: { kind: 'tool', callId: CallId(callId) },
+    },
+  ]
+}
+
+/** A two-round tool-chain history: call_A and its result, then call_B and its result. */
+function twoRoundHistory(): GenerateOptions['messages'] {
+  return [
+    ...toolRoundTripHistory('call_A'),
+    {
+      id: MessageId('m-c'),
+      role: 'assistant',
+      content: [
+        { type: 'reasoning', text: 'thinking more' },
+        { type: 'tool-call', id: CallId('call_B'), name: 'grep', arguments: '{"q":"x"}' },
+      ],
+      source: { kind: 'model', provider: 'copilot', model: 'gpt-5.6-sol' },
+    },
+    {
+      id: MessageId('m-d'),
+      role: 'user',
+      content: [{ type: 'tool-result', toolCallId: CallId('call_B'), content: [{ type: 'text', text: 'match' }] }],
+      source: { kind: 'tool', callId: CallId('call_B') },
     },
   ]
 }
 
 /** A wire-forced responses adapter with no discovery, over the global fetch stub. */
-function responsesAdapter(): CopilotAdapter {
+function responsesAdapter(tokens: TokenManager<CopilotSession> = memoryTokens(copilotSession)): CopilotAdapter {
   return new CopilotAdapter({
     models: [{ id: 'gpt-5.6-sol', wire: 'responses' }],
     streamIdleTimeoutMs: 1000,
-    tokens: memoryTokens(copilotSession),
+    tokens,
     discovery: false,
   })
 }
 
-test('adapter replays captured encrypted reasoning immediately before its tool call', async () => {
+/** A TokenManager over a session the test can swap (the relogin path). */
+function swappableTokens(initial: CopilotSession): {
+  tokens: TokenManager<CopilotSession>
+  swap(next: CopilotSession): void
+} {
+  let stored: CopilotSession | undefined = initial
+  const tokens = new TokenManager<CopilotSession>({
+    displayName: 'Test',
+    preemptMs: 0,
+    load: () => Promise.resolve(stored),
+    save: (session) => {
+      stored = session
+      return Promise.resolve()
+    },
+    remove: () => {
+      stored = undefined
+      return Promise.resolve()
+    },
+    refresh: session => Promise.resolve(session),
+    isPermanent: () => false,
+  })
+  return { tokens, swap: next => { stored = next } }
+}
+
+/** Brand a string as a GenerateOptions sessionId (the loop-stamped session identity). */
+const SessionId = (id: string): NonNullable<GenerateOptions['sessionId']> =>
+  id as NonNullable<GenerateOptions['sessionId']>
+
+/** The input items of one recorded request body. */
+function inputOf(calls: { url: string; body: Record<string, unknown> }[], index: number): Record<string, unknown>[] {
+  return calls[index]?.body.input as Record<string, unknown>[]
+}
+
+/** The encrypted payloads of the reasoning items inside one request input. */
+function replayedEncrypted(input: Record<string, unknown>[]): string[] {
+  return input.filter(item => item.type === 'reasoning').map(item => String(item.encrypted_content))
+}
+
+/**
+ * STRICT Responses-input item validation for the round-trip tests: every
+ * item must satisfy its wire schema — in particular a replayed reasoning
+ * item REQUIRES a non-empty id and encrypted_content (the pre-fix bare
+ * `{ type, encrypted_content }` shape is invalid input), a function_call
+ * requires call_id/name/JSON-parsable arguments, and a function_call_output
+ * requires call_id/output. Mock fetches cannot catch this; the validator
+ * stands in for the real gateway's schema check.
+ * @returns the violation message, or undefined when the item is valid.
+ */
+function responsesInputViolation(item: Record<string, unknown>): string | undefined {
+  switch (item.type) {
+    case 'message': {
+      if (typeof item.role !== 'string' || item.role.length === 0) return 'message: role required'
+      if (!Array.isArray(item.content) || item.content.length === 0) return 'message: content array required'
+      for (const part of item.content) {
+        const typed = part as { type?: unknown; text?: unknown }
+        if (typed.type !== 'input_text' && typed.type !== 'output_text') return 'message: content part type'
+        if (typeof typed.text !== 'string') return 'message: content part text'
+      }
+      return undefined
+    }
+    case 'reasoning': {
+      if (typeof item.id !== 'string' || item.id.length === 0) return 'reasoning: id required'
+      if (typeof item.encrypted_content !== 'string' || item.encrypted_content.length === 0) {
+        return 'reasoning: encrypted_content required'
+      }
+      if (item.summary !== undefined && !Array.isArray(item.summary)) return 'reasoning: summary must be an array'
+      return undefined
+    }
+    case 'function_call': {
+      if (typeof item.call_id !== 'string' || item.call_id.length === 0) return 'function_call: call_id required'
+      if (typeof item.name !== 'string' || item.name.length === 0) return 'function_call: name required'
+      if (typeof item.arguments !== 'string') return 'function_call: arguments string required'
+      try {
+        JSON.parse(item.arguments)
+      } catch {
+        return 'function_call: arguments must parse as JSON'
+      }
+      return undefined
+    }
+    case 'function_call_output': {
+      if (typeof item.call_id !== 'string' || item.call_id.length === 0) return 'function_call_output: call_id required'
+      if (typeof item.output !== 'string') return 'function_call_output: output required'
+      return undefined
+    }
+    default:
+      return `unknown item type ${String(item.type)}`
+  }
+}
+
+test('the strict input validator rejects an id-less reasoning item (validator sanity)', () => {
+  // The pre-fix replay shape — a bare encrypted blob — must FAIL validation,
+  // proving the round-trip assertions below actually enforce the schema.
+  assert.equal(
+    responsesInputViolation({ type: 'reasoning', encrypted_content: 'ENC' }),
+    'reasoning: id required',
+  )
+  assert.equal(
+    responsesInputViolation({ type: 'reasoning', id: 'rs_1' }),
+    'reasoning: encrypted_content required',
+  )
+  assert.equal(responsesInputViolation({ type: 'reasoning', id: 'rs_1', encrypted_content: 'ENC' }), undefined)
+})
+
+test('adapter replays the COMPLETE reasoning item immediately before its tool call', async () => {
   // Two phases through ONE adapter: the first response reasons and calls
   // call_A; the second request (tool result in hand) must replay the captured
-  // encrypted reasoning directly ahead of the replayed function_call.
+  // COMPLETED reasoning item — original id, summary, status, and the
+  // encrypted payload — directly ahead of the replayed function_call, and
+  // every assembled input item must pass the strict Responses input schema.
   const { calls, restore } = recordingSseFetch([reasoningToolCallSse('ENC1'), COMPLETED_SSE])
   try {
     const adapter = responsesAdapter()
     const first: { type: string; block?: { type?: string; id?: string } }[] = []
-    for await (const chunk of adapter.stream(STREAM_OPTIONS)) {
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1') })) {
       first.push(chunk as { type: string; block?: { type?: string; id?: string } })
     }
     const toolBlocks = first.filter(chunk => chunk.type === 'block-end' && chunk.block?.type === 'tool-call')
     assert.equal(toolBlocks.length, 1)
     assert.equal(toolBlocks[0]?.block?.id, 'call_A')
 
-    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, messages: toolRoundTripHistory() })) {
+    for await (const chunk of adapter.stream({
+      ...STREAM_OPTIONS,
+      sessionId: SessionId('sess-1'),
+      messages: toolRoundTripHistory(),
+    })) {
       void chunk
     }
-    const input = calls[1]?.body.input as Record<string, unknown>[]
+    const input = inputOf(calls, 1)
+    for (const item of input) {
+      assert.equal(
+        responsesInputViolation(item),
+        undefined,
+        `input item failed the Responses input schema: ${JSON.stringify(item)}`,
+      )
+    }
     const reasoningIndex = input.findIndex(item => item.type === 'reasoning')
-    assert.ok(reasoningIndex >= 0, 'the encrypted reasoning item is replayed')
+    assert.ok(reasoningIndex >= 0, 'the completed reasoning item is replayed')
     const callIndex = input.findIndex(item => item.type === 'function_call' && item.call_id === 'call_A')
     assert.equal(callIndex, reasoningIndex + 1)
-    assert.deepEqual(input[reasoningIndex], { type: 'reasoning', encrypted_content: 'ENC1' })
+    assert.deepEqual(input[reasoningIndex], {
+      type: 'reasoning',
+      id: 'rs_done_1',
+      summary: [{ type: 'summary_text', text: 'planned the ls call' }],
+      status: 'completed',
+      encrypted_content: 'ENC1',
+    })
   } finally {
     restore()
   }
@@ -671,14 +870,325 @@ test('a response without encrypted reasoning captures nothing to replay', async 
   const { calls, restore } = recordingSseFetch([reasoningToolCallSse(undefined), COMPLETED_SSE])
   try {
     const adapter = responsesAdapter()
-    for await (const chunk of adapter.stream(STREAM_OPTIONS)) {
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1') })) {
       void chunk
     }
-    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, messages: toolRoundTripHistory() })) {
+    for await (const chunk of adapter.stream({
+      ...STREAM_OPTIONS,
+      sessionId: SessionId('sess-1'),
+      messages: toolRoundTripHistory(),
+    })) {
       void chunk
     }
-    const input = calls[1]?.body.input as Record<string, unknown>[]
-    assert.equal(input.some(item => item.type === 'reasoning'), false)
+    assert.equal(inputOf(calls, 1).some(item => item.type === 'reasoning'), false)
+  } finally {
+    restore()
+  }
+})
+
+test('consumed replay entries persist for later rounds of the same conversation', async () => {
+  // Retention policy: consumption does NOT evict. Round 3 of a tool chain
+  // replays the reasoning of BOTH earlier responses, each ahead of its own
+  // function_call, because every later request re-sends every earlier call.
+  const { calls, restore } = recordingSseFetch([
+    reasoningToolCallSse('ENC1', 'call_A'),
+    secondReasoningToolCallSse(),
+    COMPLETED_SSE,
+  ])
+  try {
+    const adapter = responsesAdapter()
+    // Request 1 (plain prompt) → response 1 reasons (ENC1) and calls call_A.
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1') })) {
+      void chunk
+    }
+    const round = async (messages: GenerateOptions['messages']): Promise<void> => {
+      for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1'), messages })) {
+        void chunk
+      }
+    }
+    // Request 2 (call_A result) → response 2 reasons (ENC2) and calls call_B.
+    await round(toolRoundTripHistory())
+    // Request 3 (both results): replays BOTH responses' reasoning.
+    await round(twoRoundHistory())
+    const input = inputOf(calls, 2)
+    assert.deepEqual(replayedEncrypted(input), ['ENC1', 'ENC2'])
+    const enc1 = input.findIndex(item => item.type === 'reasoning' && item.encrypted_content === 'ENC1')
+    const callA = input.findIndex(item => item.type === 'function_call' && item.call_id === 'call_A')
+    const enc2 = input.findIndex(item => item.type === 'reasoning' && item.encrypted_content === 'ENC2')
+    const callB = input.findIndex(item => item.type === 'function_call' && item.call_id === 'call_B')
+    assert.equal(callA, enc1 + 1, 'round 1 reasoning replays ahead of call_A')
+    assert.equal(callB, enc2 + 1, 'round 2 reasoning replays ahead of call_B')
+    assert.ok(callA < callB)
+  } finally {
+    restore()
+  }
+})
+
+test('replay state is isolated per conversation (the loop-stamped session id)', async () => {
+  // Conversation 1 captures `call-shared`; a DIFFERENT conversation reusing
+  // the same call id (same account, same model) must not see its reasoning.
+  const { calls, restore } = recordingSseFetch([
+    reasoningToolCallSse('ENC_SESSION_1', 'call-shared'),
+    COMPLETED_SSE,
+  ])
+  try {
+    const adapter = responsesAdapter()
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1') })) {
+      void chunk
+    }
+    for await (const chunk of adapter.stream({
+      ...STREAM_OPTIONS,
+      sessionId: SessionId('sess-2'),
+      messages: toolRoundTripHistory('call-shared'),
+    })) {
+      void chunk
+    }
+    assert.equal(inputOf(calls, 1).some(item => item.type === 'reasoning'), false)
+  } finally {
+    restore()
+  }
+})
+
+test('replay state is isolated per model', async () => {
+  const { calls, restore } = recordingSseFetch([
+    reasoningToolCallSse('ENC_SOL', 'call-shared'),
+    COMPLETED_SSE,
+  ])
+  try {
+    const adapter = new CopilotAdapter({
+      models: [{ id: 'gpt-5.6-sol', wire: 'responses' }, { id: 'gpt-5.6-luna', wire: 'responses' }],
+      streamIdleTimeoutMs: 1000,
+      tokens: memoryTokens(copilotSession),
+      discovery: false,
+    })
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1') })) {
+      void chunk
+    }
+    // Same session, same call id, different model: no replay.
+    for await (const chunk of adapter.stream({
+      ...STREAM_OPTIONS,
+      model: 'gpt-5.6-luna',
+      sessionId: SessionId('sess-1'),
+      messages: toolRoundTripHistory('call-shared'),
+    })) {
+      void chunk
+    }
+    assert.equal(inputOf(calls, 1).some(item => item.type === 'reasoning'), false)
+  } finally {
+    restore()
+  }
+})
+
+test('replay state never crosses accounts (logout → relogin as another account)', async () => {
+  // The review's reproduction: account A captures call-shared →
+  // ENC_ACCOUNT_A; without rebuilding the adapter the store switches to
+  // account B, whose continuation reusing the id must NOT inject A's
+  // reasoning. The account identity rides the stable GitHub token, which
+  // survives every Copilot-token refresh and differs per login.
+  const accountA: CopilotSession = { ...copilotSession, refreshToken: 'gh-account-a' }
+  const accountB: CopilotSession = { ...copilotSession, refreshToken: 'gh-account-b' }
+  const { tokens, swap } = swappableTokens(accountA)
+  const { calls, restore } = recordingSseFetch([
+    reasoningToolCallSse('ENC_ACCOUNT_A', 'call-shared'),
+    COMPLETED_SSE,
+  ])
+  try {
+    const adapter = responsesAdapter(tokens)
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1') })) {
+      void chunk
+    }
+    swap(accountB)
+    for await (const chunk of adapter.stream({
+      ...STREAM_OPTIONS,
+      sessionId: SessionId('sess-1'),
+      messages: toolRoundTripHistory('call-shared'),
+    })) {
+      void chunk
+    }
+    assert.equal(
+      inputOf(calls, 1).some(item => item.type === 'reasoning'),
+      false,
+      "account B's request must not carry account A's reasoning",
+    )
+  } finally {
+    restore()
+  }
+})
+
+test('clearReplayState drops captured entries (the auth-transition hook)', async () => {
+  // index.ts invokes this on every copilot auth transition; even with the
+  // SAME account re-logging-in (identical scope), memory holds no replay
+  // entries afterwards.
+  const { calls, restore } = recordingSseFetch([reasoningToolCallSse('ENC1'), COMPLETED_SSE])
+  try {
+    const adapter = responsesAdapter()
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1') })) {
+      void chunk
+    }
+    adapter.clearReplayState()
+    for await (const chunk of adapter.stream({
+      ...STREAM_OPTIONS,
+      sessionId: SessionId('sess-1'),
+      messages: toolRoundTripHistory(),
+    })) {
+      void chunk
+    }
+    assert.equal(inputOf(calls, 1).some(item => item.type === 'reasoning'), false)
+  } finally {
+    restore()
+  }
+})
+
+test('captured replay entries idle out after the TTL', async () => {
+  const { calls, restore } = recordingSseFetch([reasoningToolCallSse('ENC1'), COMPLETED_SSE])
+  const realNow = Date.now
+  try {
+    const adapter = responsesAdapter()
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1') })) {
+      void chunk
+    }
+    // Fast-forward past the 30-minute TTL with no intervening use: the same
+    // scope's entry answers as a miss, degrading to the no-replay behavior.
+    const capturedAt = realNow()
+    Date.now = () => capturedAt + 31 * 60_000
+    for await (const chunk of adapter.stream({
+      ...STREAM_OPTIONS,
+      sessionId: SessionId('sess-1'),
+      messages: toolRoundTripHistory(),
+    })) {
+      void chunk
+    }
+    assert.equal(inputOf(calls, 1).some(item => item.type === 'reasoning'), false)
+  } finally {
+    Date.now = realNow
+    restore()
+  }
+})
+
+test('the TTL is idle-based: a conversation still using its entries keeps them', async () => {
+  // Sliding expiration: a read at T0+20min refreshes the entry, so a read at
+  // T0+35min (only 15 min after the last use) still replays, where a fixed
+  // TTL from capture would have dropped it.
+  const { calls, restore } = recordingSseFetch([
+    reasoningToolCallSse('ENC1'),
+    COMPLETED_SSE,
+    COMPLETED_SSE,
+  ])
+  const realNow = Date.now
+  try {
+    const adapter = responsesAdapter()
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('sess-1') })) {
+      void chunk
+    }
+    const capturedAt = realNow()
+    const continueRound = (): Promise<void> => {
+      const run = async (): Promise<void> => {
+        for await (const chunk of adapter.stream({
+          ...STREAM_OPTIONS,
+          sessionId: SessionId('sess-1'),
+          messages: toolRoundTripHistory(),
+        })) {
+          void chunk
+        }
+      }
+      return run()
+    }
+    Date.now = () => capturedAt + 20 * 60_000
+    await continueRound()
+    Date.now = () => capturedAt + 35 * 60_000
+    await continueRound()
+    assert.equal(
+      inputOf(calls, 2).some(item => item.type === 'reasoning'),
+      true,
+      'the entry survived because the last use was 15 minutes ago',
+    )
+  } finally {
+    Date.now = realNow
+    restore()
+  }
+})
+
+test('concurrent call-id collisions stay isolated per conversation', async () => {
+  // Two live conversations reuse `call-X` and capture different reasoning;
+  // each continuation replays its OWN payload, never the other's.
+  const { calls, restore } = recordingSseFetch([
+    reasoningToolCallSse('ENC_S1', 'call-X'),
+    reasoningToolCallSse('ENC_S2', 'call-X'),
+    COMPLETED_SSE,
+    COMPLETED_SSE,
+  ])
+  try {
+    const adapter = responsesAdapter()
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('s1') })) {
+      void chunk
+    }
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, sessionId: SessionId('s2') })) {
+      void chunk
+    }
+    for await (const chunk of adapter.stream({
+      ...STREAM_OPTIONS,
+      sessionId: SessionId('s1'),
+      messages: toolRoundTripHistory('call-X'),
+    })) {
+      void chunk
+    }
+    for await (const chunk of adapter.stream({
+      ...STREAM_OPTIONS,
+      sessionId: SessionId('s2'),
+      messages: toolRoundTripHistory('call-X'),
+    })) {
+      void chunk
+    }
+    assert.deepEqual(replayedEncrypted(inputOf(calls, 2)), ['ENC_S1'])
+    assert.deepEqual(replayedEncrypted(inputOf(calls, 3)), ['ENC_S2'])
+  } finally {
+    restore()
+  }
+})
+
+test('hand-built requests anchor replay on the first message id', async () => {
+  // Without a loop-stamped sessionId, the conversation scope falls back to
+  // the FIRST message's id: a continuation whose history still opens with
+  // the capturing request's first message replays, while a different
+  // hand-built conversation reusing the call id stays isolated.
+  const { calls, restore } = recordingSseFetch([
+    reasoningToolCallSse('ENC1'),
+    COMPLETED_SSE,
+    COMPLETED_SSE,
+  ])
+  try {
+    const adapter = responsesAdapter()
+    const { sessionId: omitted, ...bare } = STREAM_OPTIONS
+    void omitted
+    for await (const chunk of adapter.stream(bare)) {
+      void chunk
+    }
+    const sameConversation = [STREAM_OPTIONS.messages[0], ...toolRoundTripHistory()]
+    for await (const chunk of adapter.stream({ ...bare, messages: sameConversation })) {
+      void chunk
+    }
+    assert.equal(
+      inputOf(calls, 1).some(item => item.type === 'reasoning'),
+      true,
+      'the same first message anchors the same conversation scope',
+    )
+    const other: GenerateOptions['messages'] = [
+      {
+        id: MessageId('m-other'),
+        role: 'user',
+        content: [{ type: 'text', text: 'go' }],
+        source: { kind: 'user' },
+      },
+      ...toolRoundTripHistory(),
+    ]
+    for await (const chunk of adapter.stream({ ...bare, messages: other })) {
+      void chunk
+    }
+    assert.equal(
+      inputOf(calls, 2).some(item => item.type === 'reasoning'),
+      false,
+      'a different first message is a different conversation scope',
+    )
   } finally {
     restore()
   }

--- a/test/copilot.spec.ts
+++ b/test/copilot.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { MessageId, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import { CallId, MessageId, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { GenerateOptions } from '@deepseek-ai/dsh-llm'
 import {
   completeCopilotLogin,
@@ -200,8 +200,12 @@ test('copilotResponsesRequestBody maps the Responses wire shape', () => {
     instructions: 'be terse',
     input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
     max_output_tokens: 16_000,
+    include: ['reasoning.encrypted_content'],
     stream: true,
   })
+  // The encrypted-reasoning include is unconditional: a reasoning model needs
+  // its blobs back on the next request, and non-reasoning models ignore it.
+  assert.deepEqual(body.include, ['reasoning.encrypted_content'])
   // No system prompt → no instructions field; tools ride the Responses shape.
   const { maxTokens: omitted, ...bareOptions } = BODY_OPTIONS
   const bare = copilotResponsesRequestBody(
@@ -539,6 +543,142 @@ test('a configured wire outranks a discovered chat-wire catalog entry', async ()
     }
     assert.equal(calls.length, 1)
     assert.equal(calls[0]?.url, COPILOT_RESPONSES_URL)
+  } finally {
+    restore()
+  }
+})
+
+test('CopilotResponsesItemNormalizer captures call ids and encrypted reasoning on completion', () => {
+  const captures: { callIds: string[]; encrypted: string[] }[] = []
+  const normalizer = new CopilotResponsesItemNormalizer((callIds, encrypted) => {
+    captures.push({ callIds: [...callIds], encrypted: [...encrypted] })
+  })
+  normalizer.push({ type: 'response.output_item.added', output_index: 0, item: { type: 'reasoning', id: 'r1' } })
+  normalizer.push({ type: 'response.output_item.done', output_index: 0, item: { type: 'reasoning', id: 'r2', encrypted_content: 'ENC1' } })
+  normalizer.push({ type: 'response.output_item.added', output_index: 1, item: { type: 'function_call', id: 'f1', call_id: 'call-7', name: 'bash' } })
+  normalizer.push({ type: 'response.completed', response: {} })
+  assert.deepEqual(captures, [{ callIds: ['call-7'], encrypted: ['ENC1'] }])
+  // Cleared after the fire: a second completed event in the same stream must
+  // not re-report the first response's pair.
+  normalizer.push({ type: 'response.completed', response: {} })
+  assert.equal(captures.length, 1)
+})
+
+test('CopilotResponsesItemNormalizer does not capture without both sides of the pair', () => {
+  const captures: unknown[][] = []
+  const normalizer = new CopilotResponsesItemNormalizer((callIds, encrypted) => {
+    captures.push([callIds, encrypted])
+  })
+  // A function call with no encrypted reasoning in its response.
+  normalizer.push({ type: 'response.output_item.added', item: { type: 'function_call', id: 'f1', call_id: 'call-7' } })
+  normalizer.push({ type: 'response.completed', response: {} })
+  // Encrypted reasoning with no function call in its response.
+  normalizer.push({ type: 'response.output_item.done', item: { type: 'reasoning', id: 'r1', encrypted_content: 'ENC1' } })
+  normalizer.push({ type: 'response.completed', response: {} })
+  // Malformed shapes (empty call_id, empty encrypted_content) never collect.
+  normalizer.push({ type: 'response.output_item.added', item: { type: 'function_call', id: 'f2', call_id: '' } })
+  normalizer.push({ type: 'response.output_item.done', item: { type: 'reasoning', id: 'r2', encrypted_content: '' } })
+  normalizer.push({ type: 'response.completed', response: {} })
+  assert.equal(captures.length, 0)
+})
+
+/**
+ * SSE payload for the adapter-level capture tests: the model reasons (the
+ * reasoning done carries the encrypted blob when `encrypted` is given) and
+ * issues one tool call whose arguments arrive whole on done.
+ */
+function reasoningToolCallSse(encrypted: string | undefined): string {
+  return sseBody([
+    { type: 'response.output_item.added', output_index: 0, item: { type: 'reasoning', id: 'r1' } },
+    {
+      type: 'response.output_item.done',
+      output_index: 0,
+      item: encrypted === undefined
+        ? { type: 'reasoning', id: 'r2' }
+        : { type: 'reasoning', id: 'r2', encrypted_content: encrypted },
+    },
+    { type: 'response.output_item.added', output_index: 1, item: { type: 'function_call', id: 'f1', call_id: 'call_A', name: 'bash' } },
+    { type: 'response.function_call_arguments.delta', output_index: 1, item_id: 'f2', delta: '' },
+    { type: 'response.output_item.done', output_index: 1, item: { type: 'function_call', id: 'f3', call_id: 'call_A', name: 'bash', arguments: '{"cmd":"ls"}' } },
+    { type: 'response.completed', response: { usage: { input_tokens: 3, output_tokens: 4 } } },
+  ])
+}
+
+/** The conversation handed back for the second request after call_A ran. */
+function toolRoundTripHistory(): GenerateOptions['messages'] {
+  return [
+    {
+      id: MessageId('m-a'),
+      role: 'assistant',
+      content: [
+        { type: 'reasoning', text: 'thinking' },
+        { type: 'tool-call', id: CallId('call_A'), name: 'bash', arguments: '{"cmd":"ls"}' },
+      ],
+      source: { kind: 'model', provider: 'copilot', model: 'gpt-5.6-sol' },
+    },
+    {
+      id: MessageId('m-b'),
+      role: 'user',
+      content: [{ type: 'tool-result', toolCallId: CallId('call_A'), content: [{ type: 'text', text: 'file-a' }] }],
+      source: { kind: 'tool', callId: CallId('call_A') },
+    },
+  ]
+}
+
+/** A wire-forced responses adapter with no discovery, over the global fetch stub. */
+function responsesAdapter(): CopilotAdapter {
+  return new CopilotAdapter({
+    models: [{ id: 'gpt-5.6-sol', wire: 'responses' }],
+    streamIdleTimeoutMs: 1000,
+    tokens: memoryTokens(copilotSession),
+    discovery: false,
+  })
+}
+
+test('adapter replays captured encrypted reasoning immediately before its tool call', async () => {
+  // Two phases through ONE adapter: the first response reasons and calls
+  // call_A; the second request (tool result in hand) must replay the captured
+  // encrypted reasoning directly ahead of the replayed function_call.
+  const { calls, restore } = recordingSseFetch([reasoningToolCallSse('ENC1'), COMPLETED_SSE])
+  try {
+    const adapter = responsesAdapter()
+    const first: { type: string; block?: { type?: string; id?: string } }[] = []
+    for await (const chunk of adapter.stream(STREAM_OPTIONS)) {
+      first.push(chunk as { type: string; block?: { type?: string; id?: string } })
+    }
+    const toolBlocks = first.filter(chunk => chunk.type === 'block-end' && chunk.block?.type === 'tool-call')
+    assert.equal(toolBlocks.length, 1)
+    assert.equal(toolBlocks[0]?.block?.id, 'call_A')
+
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, messages: toolRoundTripHistory() })) {
+      void chunk
+    }
+    const input = calls[1]?.body.input as Record<string, unknown>[]
+    const reasoningIndex = input.findIndex(item => item.type === 'reasoning')
+    assert.ok(reasoningIndex >= 0, 'the encrypted reasoning item is replayed')
+    const callIndex = input.findIndex(item => item.type === 'function_call' && item.call_id === 'call_A')
+    assert.equal(callIndex, reasoningIndex + 1)
+    assert.deepEqual(input[reasoningIndex], { type: 'reasoning', encrypted_content: 'ENC1' })
+  } finally {
+    restore()
+  }
+})
+
+test('a response without encrypted reasoning captures nothing to replay', async () => {
+  // Degradation: the reasoning item arrives without encrypted_content (model
+  // not reasoning, or the gateway strips the blob) — the follow-up request's
+  // input carries no reasoning items, exactly the pre-capture behavior.
+  const { calls, restore } = recordingSseFetch([reasoningToolCallSse(undefined), COMPLETED_SSE])
+  try {
+    const adapter = responsesAdapter()
+    for await (const chunk of adapter.stream(STREAM_OPTIONS)) {
+      void chunk
+    }
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, messages: toolRoundTripHistory() })) {
+      void chunk
+    }
+    const input = calls[1]?.body.input as Record<string, unknown>[]
+    assert.equal(input.some(item => item.type === 'reasoning'), false)
   } finally {
     restore()
   }

--- a/test/copilot.spec.ts
+++ b/test/copilot.spec.ts
@@ -17,6 +17,7 @@ import {
   CopilotResponsesItemNormalizer,
   copilotChatRequestBody,
   copilotResponsesRequestBody,
+  copilotRequestWire,
   copilotWireFor,
   exchangeCopilotToken,
   FALLBACK_VSCODE_VERSION,
@@ -218,6 +219,39 @@ test('copilotWireFor defaults to chat completions unless the catalog says respon
   assert.equal(copilotWireFor(responses), 'responses')
   // An entry without the flag (static fallback path) stays on the chat wire.
   assert.equal(copilotWireFor({ id: 'gpt-4o', name: 'GPT-4o' }), 'chat-completions')
+})
+
+test('copilotRequestWire reroutes dual-protocol models to Responses for tools + effort', () => {
+  // gpt-5.4 lists both endpoints: chat by default, but Copilot 400s there
+  // once a request combines function tools with a reasoning effort
+  // ("use /v1/responses or set reasoning_effort to 'none'").
+  const dual: DiscoveredModel = {
+    id: 'gpt-5.4',
+    name: 'GPT-5.4',
+    copilotWire: 'chat-completions',
+    copilotResponses: true,
+  }
+  const tools = [{ name: 'bash', description: 'run', parameters: { type: 'object' } }]
+  assert.equal(copilotRequestWire(dual, { tools, reasoningEffort: ReasoningEffortId('medium') }), 'responses')
+  assert.equal(copilotRequestWire(dual, { tools, reasoningEffort: ReasoningEffortId('xhigh') }), 'responses')
+  // 'none' is the one effort the chat wire accepts alongside tools.
+  assert.equal(copilotRequestWire(dual, { tools, reasoningEffort: ReasoningEffortId('none') }), 'chat-completions')
+  // Effort without tools, or tools without effort, keep the default wire.
+  assert.equal(copilotRequestWire(dual, { reasoningEffort: ReasoningEffortId('medium') }), 'chat-completions')
+  assert.equal(copilotRequestWire(dual, { tools }), 'chat-completions')
+  assert.equal(copilotRequestWire(dual, {}), 'chat-completions')
+  // A model listing no `/responses` (claude, kimi, …) never reroutes.
+  const chatOnly: DiscoveredModel = { id: 'kimi-k3', name: 'Kimi K3', copilotWire: 'chat-completions' }
+  assert.equal(
+    copilotRequestWire(chatOnly, { tools, reasoningEffort: ReasoningEffortId('high') }),
+    'chat-completions',
+  )
+  // Responses-only models and unknown entries keep their wire untouched.
+  assert.equal(
+    copilotRequestWire({ id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', copilotWire: 'responses' }, {}),
+    'responses',
+  )
+  assert.equal(copilotRequestWire(undefined, {}), 'chat-completions')
 })
 
 test('CopilotResponsesItemNormalizer folds per-event item ids into one stable key', () => {

--- a/test/copilot.spec.ts
+++ b/test/copilot.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { MessageId } from '@deepseek-ai/dsh-llm'
+import { MessageId, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { GenerateOptions } from '@deepseek-ai/dsh-llm'
 import {
   completeCopilotLogin,
@@ -169,8 +169,21 @@ test('copilotChatRequestBody sends max_completion_tokens, never max_tokens', () 
   const body = copilotChatRequestBody(BODY_OPTIONS, [{ role: 'user', content: 'hi' }])
   assert.equal(body.max_completion_tokens, 16_000)
   assert.equal('max_tokens' in body, false)
+  assert.equal('reasoning_effort' in body, false)
   assert.equal(body.stream, true)
   assert.deepEqual(body.stream_options, { include_usage: true })
+})
+
+test('copilotChatRequestBody maps the selected effort to reasoning_effort', () => {
+  const options = { ...BODY_OPTIONS, reasoningEffort: ReasoningEffortId('high') }
+  const body = copilotChatRequestBody(options, [{ role: 'user', content: 'hi' }])
+  assert.equal(body.reasoning_effort, 'high')
+})
+
+test('copilotResponsesRequestBody maps the selected effort to reasoning.effort', () => {
+  const options = { ...BODY_OPTIONS, reasoningEffort: ReasoningEffortId('xhigh') }
+  const body = copilotResponsesRequestBody(options, { input: [] })
+  assert.deepEqual(body.reasoning, { effort: 'xhigh' })
 })
 
 test('copilotResponsesRequestBody maps the Responses wire shape', () => {

--- a/test/copilot.spec.ts
+++ b/test/copilot.spec.ts
@@ -256,7 +256,9 @@ test('copilotRequestWire reroutes dual-protocol models to Responses for tools + 
 
 test('CopilotResponsesItemNormalizer folds per-event item ids into one stable key', () => {
   // Raw shape captured from api.githubcopilot.com/responses with gpt-5.6:
-  // every event of one item carries a DIFFERENT opaque id.
+  // every event of one item carries a DIFFERENT opaque id. These captures
+  // carry no output_index, so this test pins the last-added-key fallback and
+  // must keep passing byte for byte.
   const normalizer = new CopilotResponsesItemNormalizer()
   const rewritten = [
     { type: 'response.output_item.added', item: { type: 'message', id: 'added-id' } },
@@ -308,4 +310,79 @@ test('normalized Copilot Responses events assemble text and whole-done tool argu
   assert.equal(blocks[1]?.arguments, '{"cmd":"ls"}')
   const finish = chunks.find(chunk => chunk.type === 'finish')
   assert.equal(finish?.type, 'finish')
+})
+
+test('CopilotResponsesItemNormalizer keys interleaved items by output_index, not arrival order', () => {
+  // Two items interleaved on the wire (parallel tool calls): every event
+  // carries a fresh gateway id, so output_index is the only correlator.
+  const normalizer = new CopilotResponsesItemNormalizer()
+  const itemKey = (event: ResponsesStreamEvent): string | undefined => {
+    const rewritten = normalizer.push(event)
+    return rewritten.item?.id ?? rewritten.item_id
+  }
+  assert.equal(
+    itemKey({ type: 'response.output_item.added', output_index: 0, item: { type: 'function_call', id: 'A1', call_id: 'call-A', name: 'bash' } }),
+    'copilot-item-0',
+  )
+  assert.equal(
+    itemKey({ type: 'response.output_item.added', output_index: 1, item: { type: 'function_call', id: 'B1', call_id: 'call-B', name: 'grep' } }),
+    'copilot-item-1',
+  )
+  // Interleaved deltas and dones land on their own item's key.
+  assert.equal(
+    itemKey({ type: 'response.function_call_arguments.delta', output_index: 0, item_id: 'A2', delta: '' }),
+    'copilot-item-0',
+  )
+  assert.equal(
+    itemKey({ type: 'response.function_call_arguments.delta', output_index: 1, item_id: 'B2', delta: '' }),
+    'copilot-item-1',
+  )
+  assert.equal(
+    itemKey({ type: 'response.output_item.done', output_index: 0, item: { type: 'function_call', id: 'A3' } }),
+    'copilot-item-0',
+  )
+  assert.equal(
+    itemKey({ type: 'response.output_item.done', output_index: 1, item: { type: 'function_call', id: 'B3' } }),
+    'copilot-item-1',
+  )
+  // A no-index event falls back to the LAST added item's key.
+  assert.equal(itemKey({ type: 'response.output_text.delta', item_id: 'late', delta: 'x' }), 'copilot-item-1')
+})
+
+/** Encode Responses events as the SSE byte stream the adapter consumes. */
+function sseStream(events: ResponsesStreamEvent[]): ReadableStream<Uint8Array> {
+  const frames = events.map(event => `data: ${JSON.stringify(event)}\n\n`).join('') + 'data: [DONE]\n\n'
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(frames))
+      controller.close()
+    },
+  })
+}
+
+test('normalized interleaved Copilot tool calls assemble into separate blocks', async () => {
+  // End-to-end through the shared translator: two function calls interleaved
+  // per-event (fresh ids everywhere, output_index the only correlator), each
+  // call's arguments delivered whole only on its done event.
+  const normalizer = new CopilotResponsesItemNormalizer()
+  const events: ResponsesStreamEvent[] = [
+    { type: 'response.output_item.added', output_index: 0, item: { type: 'function_call', id: 'a1', call_id: 'call-A', name: 'bash' } },
+    { type: 'response.output_item.added', output_index: 1, item: { type: 'function_call', id: 'b1', call_id: 'call-B', name: 'grep' } },
+    { type: 'response.function_call_arguments.delta', output_index: 0, item_id: 'a2', delta: '' },
+    { type: 'response.function_call_arguments.delta', output_index: 1, item_id: 'b2', delta: '' },
+    { type: 'response.output_item.done', output_index: 0, item: { type: 'function_call', id: 'a3', call_id: 'call-A', name: 'bash', arguments: '{"cmd":"ls"}' } },
+    { type: 'response.output_item.done', output_index: 1, item: { type: 'function_call', id: 'b3', call_id: 'call-B', name: 'grep', arguments: '{"q":"x"}' } },
+    { type: 'response.completed', response: { usage: { input_tokens: 5, output_tokens: 3 } } },
+  ]
+  const chunks: { type: string; block?: { type: string; id?: string; name?: string; arguments?: string } }[] = []
+  for await (const chunk of streamResponses(sseStream(events), undefined, event => normalizer.push(event))) {
+    chunks.push(chunk as { type: string; block?: { type: string; id?: string; name?: string; arguments?: string } })
+  }
+  // Each call closes as its own tool-call block with its own arguments.
+  const blocks = chunks.filter(chunk => chunk.type === 'block-end').map(chunk => chunk.block)
+  assert.deepEqual(blocks, [
+    { type: 'tool-call', id: 'call-A', name: 'bash', arguments: '{"cmd":"ls"}' },
+    { type: 'tool-call', id: 'call-B', name: 'grep', arguments: '{"q":"x"}' },
+  ])
+  assert.deepEqual(chunks.find(chunk => chunk.type === 'finish'), { type: 'finish', reason: { kind: 'tool-calls' } })
 })

--- a/test/copilot.spec.ts
+++ b/test/copilot.spec.ts
@@ -13,7 +13,10 @@ import { MessageId, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { GenerateOptions } from '@deepseek-ai/dsh-llm'
 import {
   completeCopilotLogin,
+  COPILOT_MODELS_URL,
+  COPILOT_RESPONSES_URL,
   COPILOT_TOKEN_URL,
+  CopilotAdapter,
   CopilotResponsesItemNormalizer,
   copilotChatRequestBody,
   copilotResponsesRequestBody,
@@ -27,8 +30,8 @@ import {
   refreshCopilot,
   VSCODE_RELEASES_URL,
 } from '../src/providers/copilot.js'
-import { OAuthEndpointError } from '../src/providers/common.js'
-import type { DiscoveredModel, FetchFn } from '../src/providers/common.js'
+import { OAuthEndpointError, TokenManager, validateModels } from '../src/providers/common.js'
+import type { DiscoveredModel, FetchFn, ModelEntry } from '../src/providers/common.js'
 import type { CopilotSession } from '../src/auth/store.js'
 import { streamResponses } from '../src/translate/responses.js'
 import type { ResponsesStreamEvent } from '../src/translate/responses.js'
@@ -349,9 +352,14 @@ test('CopilotResponsesItemNormalizer keys interleaved items by output_index, not
   assert.equal(itemKey({ type: 'response.output_text.delta', item_id: 'late', delta: 'x' }), 'copilot-item-1')
 })
 
+/** Encode Responses events as one SSE payload string. */
+function sseBody(events: ResponsesStreamEvent[]): string {
+  return events.map(event => `data: ${JSON.stringify(event)}\n\n`).join('') + 'data: [DONE]\n\n'
+}
+
 /** Encode Responses events as the SSE byte stream the adapter consumes. */
 function sseStream(events: ResponsesStreamEvent[]): ReadableStream<Uint8Array> {
-  const frames = events.map(event => `data: ${JSON.stringify(event)}\n\n`).join('') + 'data: [DONE]\n\n'
+  const frames = sseBody(events)
   return new ReadableStream({
     start(controller) {
       controller.enqueue(new TextEncoder().encode(frames))
@@ -385,4 +393,153 @@ test('normalized interleaved Copilot tool calls assemble into separate blocks', 
     { type: 'tool-call', id: 'call-B', name: 'grep', arguments: '{"q":"x"}' },
   ])
   assert.deepEqual(chunks.find(chunk => chunk.type === 'finish'), { type: 'finish', reason: { kind: 'tool-calls' } })
+})
+
+test('validateModels passes a configured wire through and rejects unknown values', () => {
+  assert.deepEqual(
+    validateModels([{ id: 'gpt-5.6-sol', wire: 'responses' }], 'test: copilot'),
+    [{ id: 'gpt-5.6-sol', wire: 'responses' }],
+  )
+  const bogus: unknown = { id: 'm', wire: 'bogus' }
+  assert.throws(
+    () => validateModels([bogus as ModelEntry], 'test: copilot'),
+    /test: copilot: catalog model "m" wire must be "chat-completions" or "responses"/,
+  )
+})
+
+const copilotSession: CopilotSession = {
+  accessToken: 'copilot-at',
+  refreshToken: 'gh-token',
+  expiresAt: Date.now() + 3_600_000,
+}
+
+/** A TokenManager over an in-memory session; refresh never fires here. */
+function memoryTokens(initial: CopilotSession): TokenManager<CopilotSession> {
+  let stored: CopilotSession | undefined = initial
+  return new TokenManager<CopilotSession>({
+    displayName: 'Test',
+    preemptMs: 0,
+    load: () => Promise.resolve(stored),
+    save: (session) => {
+      stored = session
+      return Promise.resolve()
+    },
+    remove: () => {
+      stored = undefined
+      return Promise.resolve()
+    },
+    refresh: session => Promise.resolve(session),
+    isPermanent: () => false,
+  })
+}
+
+/**
+ * Record-and-replay stub for the AMBIENT generation fetch: the adapter sends
+ * provider traffic through global fetch (the repo-wide adapter pattern; only
+ * discovery takes an injected fetchFn), so adapter-level stream tests patch
+ * the global and restore it in a finally. node:test runs one file's tests
+ * sequentially, so the patch window is race-free. Each queued SSE payload
+ * answers one request in call order; request url + parsed body are recorded.
+ */
+function recordingSseFetch(queuedResponses: string[]): {
+  calls: { url: string; body: Record<string, unknown> }[]
+  restore(): void
+} {
+  const original = globalThis.fetch
+  const calls: { url: string; body: Record<string, unknown> }[] = []
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    if (url === VSCODE_RELEASES_URL) {
+      return Promise.resolve(new Response(JSON.stringify(['1.9.9']), { status: 200 }))
+    }
+    calls.push({ url, body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown> })
+    const payload = queuedResponses.shift()
+    if (payload === undefined) return Promise.reject(new Error(`unexpected fetch to ${url}`))
+    return Promise.resolve(new Response(payload))
+  }) as typeof globalThis.fetch
+  return { calls, restore: () => { globalThis.fetch = original } }
+}
+
+/** A minimal completed Responses SSE payload (one text item, then finish). */
+const COMPLETED_SSE = sseBody([
+  { type: 'response.output_item.added', output_index: 0, item: { type: 'message', id: 'm1' } },
+  { type: 'response.output_item.done', output_index: 0, item: { type: 'message', id: 'm2', content: [{ type: 'output_text', text: 'ok' }] } },
+  { type: 'response.completed', response: { usage: { input_tokens: 1, output_tokens: 1 } } },
+])
+
+/** Minimal generate options for adapter.stream() calls. */
+const STREAM_OPTIONS: GenerateOptions = {
+  provider: 'copilot',
+  model: 'gpt-5.6-sol',
+  messages: [{
+    id: MessageId('m-stream'),
+    role: 'user',
+    content: [{ type: 'text', text: 'hi' }],
+    source: { kind: 'user' },
+  }],
+  maxTokens: 1_000,
+}
+
+test('a configured wire routes the request even without discovery', async () => {
+  // Review finding on #26: a manually configured responses-only model with
+  // discovery:false left discovered() undefined, so the request silently
+  // defaulted to /chat/completions and the gateway rejected it.
+  const { calls, restore } = recordingSseFetch([COMPLETED_SSE])
+  try {
+    const adapter = new CopilotAdapter({
+      models: [{ id: 'gpt-5.6-sol', wire: 'responses' }],
+      streamIdleTimeoutMs: 1000,
+      tokens: memoryTokens(copilotSession),
+      discovery: false,
+    })
+    const chunks: { type: string }[] = []
+    for await (const chunk of adapter.stream(STREAM_OPTIONS)) {
+      chunks.push(chunk as { type: string })
+    }
+    assert.equal(chunks.at(-1)?.type, 'finish')
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0]?.url, COPILOT_RESPONSES_URL)
+    assert.equal(calls[0]?.body.model, 'gpt-5.6-sol')
+  } finally {
+    restore()
+  }
+})
+
+test('a configured wire outranks a discovered chat-wire catalog entry', async () => {
+  // Discovery (were it consulted) reports gpt-4.1 as /chat/completions, but
+  // the config pins it to responses: the explicit config wins, and the
+  // discovery fetch is never needed for the routing decision.
+  const discovery: FetchFn = ((input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url === VSCODE_RELEASES_URL) return Promise.resolve(new Response(JSON.stringify(['1.9.9'])))
+    if (url === COPILOT_MODELS_URL) {
+      return Promise.resolve(new Response(JSON.stringify({
+        data: [{
+          id: 'gpt-4.1',
+          name: 'GPT-4.1',
+          model_picker_enabled: true,
+          policy: { state: 'enabled' },
+          supported_endpoints: ['/chat/completions'],
+        }],
+      })))
+    }
+    return Promise.reject(new Error(`unexpected discovery fetch to ${url}`))
+  }) as FetchFn
+  const { calls, restore } = recordingSseFetch([COMPLETED_SSE])
+  try {
+    const adapter = new CopilotAdapter({
+      models: [{ id: 'gpt-4.1', wire: 'responses' }],
+      streamIdleTimeoutMs: 1000,
+      tokens: memoryTokens(copilotSession),
+      discovery: true,
+      fetchFn: discovery,
+    })
+    for await (const chunk of adapter.stream({ ...STREAM_OPTIONS, model: 'gpt-4.1' })) {
+      void chunk
+    }
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0]?.url, COPILOT_RESPONSES_URL)
+  } finally {
+    restore()
+  }
 })

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -643,7 +643,9 @@ const COPILOT_MODELS_PAYLOAD = {
       model_picker_enabled: true,
       policy: { state: 'enabled' },
       supported_endpoints: ['/chat/completions', '/responses'],
-      capabilities: { supports: { vision: false } },
+      capabilities: {
+        supports: { vision: false, reasoning_effort: ['low', 'medium', 'high'] },
+      },
     },
     {
       id: 'gpt-5.6-sol',
@@ -653,7 +655,7 @@ const COPILOT_MODELS_PAYLOAD = {
       // The newer GPT families only list the Responses endpoint.
       supported_endpoints: ['/responses', 'ws:/responses'],
       capabilities: {
-        supports: { vision: true },
+        supports: { vision: true, reasoning_effort: ['low', 'medium', 'high', 'xhigh'] },
         limits: { max_context_window_tokens: 1_050_000 },
       },
     },
@@ -695,6 +697,67 @@ test('copilot discovery records the wire protocol per model', async () => {
     ['gpt-5.6-sol', 'responses'],
   ])
   assert.equal(discovered[2]?.contextWindow, 1_050_000)
+})
+
+test('copilot discovery maps the supports.reasoning_effort array into efforts', async () => {
+  const { fetchFn } = fakeFetch(COPILOT_MODELS_PAYLOAD)
+  const discovered = await fetchCopilotModels(copilotSession, fetchFn)
+  // A model without the array (or with null/empty) exposes no efforts.
+  assert.equal(discovered[0]?.reasoning, undefined)
+  const o4 = discovered[1]?.reasoning
+  assert.deepEqual(o4?.efforts.map(effort => [effort.id, effort.name]), [
+    ['low', 'Low'],
+    ['medium', 'Medium'],
+    ['high', 'High'],
+  ])
+  assert.equal(o4?.defaultEffort, undefined)
+  const sol = discovered[2]?.reasoning
+  assert.equal(sol?.efforts[3]?.name, 'Extra High')
+})
+
+test('copilot discovery tolerates duplicate, empty, and null effort entries', async () => {
+  const models = await fetchCopilotModels(copilotSession, fakeFetch({
+    data: [
+      {
+        id: 'gpt-5.1',
+        name: 'GPT-5.1',
+        model_picker_enabled: true,
+        policy: { state: 'enabled' },
+        supported_endpoints: ['/chat/completions'],
+        capabilities: { supports: { reasoning_effort: ['high', 'high', '', 'max'] } },
+      },
+      {
+        id: 'claude-opus-4-5',
+        name: 'Claude Opus 4.5',
+        model_picker_enabled: true,
+        policy: { state: 'enabled' },
+        supported_endpoints: ['/chat/completions'],
+        capabilities: { supports: { reasoning_effort: null } },
+      },
+    ],
+  }).fetchFn)
+  // Duplicates collapse and empty strings drop (the harness rejects duplicate
+  // effort ids); "max" survives with a display name.
+  assert.deepEqual(models[0]?.reasoning?.efforts.map(effort => [effort.id, effort.name]), [
+    ['high', 'High'],
+    ['max', 'Max'],
+  ])
+  assert.equal(models[1]?.reasoning, undefined)
+})
+
+test('copilot resolveModel serves discovered reasoning efforts', async () => {
+  const { fetchFn } = fakeFetch(COPILOT_MODELS_PAYLOAD)
+  const adapter = copilotAdapter({ session: copilotSession, fetchFn })
+  await adapter.listModels('copilot')
+  const resolved = await adapter.resolveModel('copilot', 'o4-mini')
+  assert.deepEqual(resolved.reasoning?.efforts.map(effort => effort.id), ['low', 'medium', 'high'])
+  const sol = await adapter.resolveModel('copilot', 'gpt-5.6-sol')
+  assert.deepEqual(sol.reasoning?.efforts.map(effort => effort.id), ['low', 'medium', 'high', 'xhigh'])
+  // A model the catalog listed without efforts (and one it filtered out,
+  // falling back to static metadata) claims no reasoning at all: the harness
+  // then rejects explicit efforts before the API can 400.
+  assert.equal((await adapter.resolveModel('copilot', 'gpt-4.1')).reasoning, undefined)
+  assert.equal((await adapter.resolveModel('copilot', 'policy-disabled')).reasoning, undefined)
 })
 
 test('copilot resolveModel serves discovered context windows and modalities', async () => {

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -692,10 +692,15 @@ test('copilot discovery records the wire protocol per model', async () => {
   const discovered = await fetchCopilotModels(copilotSession, fetchFn)
   assert.deepEqual(discovered.map(model => [model.id, model.copilotWire ?? 'chat-completions']), [
     ['gpt-4.1', 'chat-completions'],
-    // Both endpoints listed → the chat wire (models listing both accept it).
+    // Both endpoints listed → the chat wire (models listing both accept it),
+    // with /responses availability recorded for the tools+effort reroute.
     ['o4-mini', 'chat-completions'],
     ['gpt-5.6-sol', 'responses'],
   ])
+  // The dual-protocol flag rides only entries listing /responses.
+  assert.equal(discovered[0]?.copilotResponses, undefined)
+  assert.equal(discovered[1]?.copilotResponses, true)
+  assert.equal(discovered[2]?.copilotResponses, true)
   assert.equal(discovered[2]?.contextWindow, 1_050_000)
 })
 

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -11,7 +11,7 @@ import { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import { CodexAdapter, codexRequestBody, fetchCodexModels } from '../src/providers/codex.js'
 import { GrokAdapter } from '../src/providers/grok.js'
 import { ClaudeAdapter } from '../src/providers/claude.js'
-import { CopilotAdapter } from '../src/providers/copilot.js'
+import { CopilotAdapter, fetchCopilotModels } from '../src/providers/copilot.js'
 import { ModelCatalogCache, TokenManager } from '../src/providers/common.js'
 import type { CatalogPersistence, CatalogSnapshot, FetchFn } from '../src/providers/common.js'
 import type { ClaudeSession, CodexSession, CopilotSession, GrokSession } from '../src/auth/store.js'
@@ -645,13 +645,25 @@ const COPILOT_MODELS_PAYLOAD = {
       supported_endpoints: ['/chat/completions', '/responses'],
       capabilities: { supports: { vision: false } },
     },
+    {
+      id: 'gpt-5.6-sol',
+      name: 'GPT-5.6 Sol',
+      model_picker_enabled: true,
+      policy: { state: 'enabled' },
+      // The newer GPT families only list the Responses endpoint.
+      supported_endpoints: ['/responses', 'ws:/responses'],
+      capabilities: {
+        supports: { vision: true },
+        limits: { max_context_window_tokens: 1_050_000 },
+      },
+    },
     { id: 'picker-hidden', model_picker_enabled: false, policy: { state: 'enabled' } },
     { id: 'policy-disabled', model_picker_enabled: true, policy: { state: 'disabled' } },
     {
-      id: 'responses-only',
+      id: 'ws-only',
       model_picker_enabled: true,
       policy: { state: 'enabled' },
-      supported_endpoints: ['/responses'],
+      supported_endpoints: ['ws:/responses'],
     },
   ],
 }
@@ -665,11 +677,24 @@ test('copilot listModels maps the discovered catalog and filters unusable entrie
   const { fetchFn } = fakeFetch(COPILOT_MODELS_PAYLOAD)
   const adapter = copilotAdapter({ session: copilotSession, fetchFn })
   const models = await adapter.listModels('copilot')
-  assert.deepEqual(models.map(model => model.id), ['gpt-4.1', 'o4-mini'])
+  assert.deepEqual(models.map(model => model.id), ['gpt-4.1', 'o4-mini', 'gpt-5.6-sol'])
   // Vision support from the catalog becomes the model's input modalities.
   assert.deepEqual(models[0].inputModalities, ['text', 'image'])
   assert.deepEqual(models[1].inputModalities, ['text'])
+  assert.deepEqual(models[2].inputModalities, ['text', 'image'])
   assert.equal(models[0].name, 'GPT-4.1')
+})
+
+test('copilot discovery records the wire protocol per model', async () => {
+  const { fetchFn } = fakeFetch(COPILOT_MODELS_PAYLOAD)
+  const discovered = await fetchCopilotModels(copilotSession, fetchFn)
+  assert.deepEqual(discovered.map(model => [model.id, model.copilotWire ?? 'chat-completions']), [
+    ['gpt-4.1', 'chat-completions'],
+    // Both endpoints listed → the chat wire (models listing both accept it).
+    ['o4-mini', 'chat-completions'],
+    ['gpt-5.6-sol', 'responses'],
+  ])
+  assert.equal(discovered[2]?.contextWindow, 1_050_000)
 })
 
 test('copilot resolveModel serves discovered context windows and modalities', async () => {

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -84,6 +84,43 @@ test('toResponsesInput: system-role messages become instructions unless options.
   assert.equal(explicit.instructions, 'explicit system')
 })
 
+test('toResponsesInput: reasoningFor replays encrypted reasoning ahead of the tool call', () => {
+  const messages = () => [
+    message('user', [{ type: 'text', text: 'go' }]),
+    message('assistant', [
+      toolCall('call-1', 'bash', '{}'),
+      toolCall('call-2', 'grep', '{}'),
+    ]),
+  ]
+  // Parallel calls of one response share ONE array instance → replay once,
+  // before the first call.
+  const shared = ['ENC1', 'ENC2']
+  assert.deepEqual(toResponsesInput(messages(), undefined, () => shared).input, [
+    { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'go' }] },
+    { type: 'reasoning', encrypted_content: 'ENC1' },
+    { type: 'reasoning', encrypted_content: 'ENC2' },
+    { type: 'function_call', call_id: 'call-1', name: 'bash', arguments: '{}' },
+    { type: 'function_call', call_id: 'call-2', name: 'grep', arguments: '{}' },
+  ])
+  // Distinct arrays per call → each replays ahead of its own call.
+  const byCall: Record<string, string[]> = { 'call-1': ['E1'], 'call-2': ['E2'] }
+  assert.deepEqual(toResponsesInput(messages(), undefined, callId => byCall[callId]).input, [
+    { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'go' }] },
+    { type: 'reasoning', encrypted_content: 'E1' },
+    { type: 'function_call', call_id: 'call-1', name: 'bash', arguments: '{}' },
+    { type: 'reasoning', encrypted_content: 'E2' },
+    { type: 'function_call', call_id: 'call-2', name: 'grep', arguments: '{}' },
+  ])
+  // An unknown call id injects nothing.
+  const toolOnly = [{ type: 'function_call', call_id: 'call-x', name: 'bash', arguments: '{}' }]
+  assert.deepEqual(
+    toResponsesInput([message('assistant', [toolCall('call-x', 'bash', '{}')])], undefined, () => undefined).input,
+    toolOnly,
+  )
+  // Omitting the callback keeps the pre-replay behavior.
+  assert.deepEqual(toResponsesInput([message('assistant', [toolCall('call-x', 'bash', '{}')])]).input, toolOnly)
+})
+
 test('toResponsesTools maps to Responses function tools', () => {
   assert.deepEqual(toResponsesTools([{ name: 'bash', description: 'run', parameters: { type: 'object' } }]), [
     { type: 'function', name: 'bash', description: 'run', parameters: { type: 'object' } },

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -13,7 +13,7 @@ import {
   toResponsesInput,
   toResponsesTools,
 } from '../src/translate/responses.js'
-import type { ResponsesStreamEvent } from '../src/translate/responses.js'
+import type { ReasoningReplayItem, ResponsesStreamEvent } from '../src/translate/responses.js'
 import {
   AnthropicStreamTranslator,
   CLAUDE_CODE_IDENTITY,
@@ -84,7 +84,7 @@ test('toResponsesInput: system-role messages become instructions unless options.
   assert.equal(explicit.instructions, 'explicit system')
 })
 
-test('toResponsesInput: reasoningFor replays encrypted reasoning ahead of the tool call', () => {
+test('toResponsesInput: reasoningFor replays completed reasoning items ahead of the tool call', () => {
   const messages = () => [
     message('user', [{ type: 'text', text: 'go' }]),
     message('assistant', [
@@ -92,25 +92,50 @@ test('toResponsesInput: reasoningFor replays encrypted reasoning ahead of the to
       toolCall('call-2', 'grep', '{}'),
     ]),
   ]
+  // The replay shape is the COMPLETE reasoning item: the Responses input
+  // schema does not treat a reasoning item's id or summary as optional.
+  const item = (id: string, enc: string): ReasoningReplayItem => ({
+    type: 'reasoning',
+    id,
+    summary: [{ type: 'summary_text', text: 'thought' }],
+    status: 'completed',
+    encrypted_content: enc,
+  })
   // Parallel calls of one response share ONE array instance → replay once,
   // before the first call.
-  const shared = ['ENC1', 'ENC2']
+  const shared = [item('rs_1', 'ENC1'), item('rs_2', 'ENC2')]
   assert.deepEqual(toResponsesInput(messages(), undefined, () => shared).input, [
     { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'go' }] },
-    { type: 'reasoning', encrypted_content: 'ENC1' },
-    { type: 'reasoning', encrypted_content: 'ENC2' },
+    { type: 'reasoning', id: 'rs_1', summary: [{ type: 'summary_text', text: 'thought' }], status: 'completed', encrypted_content: 'ENC1' },
+    { type: 'reasoning', id: 'rs_2', summary: [{ type: 'summary_text', text: 'thought' }], status: 'completed', encrypted_content: 'ENC2' },
     { type: 'function_call', call_id: 'call-1', name: 'bash', arguments: '{}' },
     { type: 'function_call', call_id: 'call-2', name: 'grep', arguments: '{}' },
   ])
   // Distinct arrays per call → each replays ahead of its own call.
-  const byCall: Record<string, string[]> = { 'call-1': ['E1'], 'call-2': ['E2'] }
+  const byCall: Record<string, ReasoningReplayItem[]> = {
+    'call-1': [item('rs_1', 'E1')],
+    'call-2': [item('rs_2', 'E2')],
+  }
   assert.deepEqual(toResponsesInput(messages(), undefined, callId => byCall[callId]).input, [
     { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'go' }] },
-    { type: 'reasoning', encrypted_content: 'E1' },
+    { type: 'reasoning', id: 'rs_1', summary: [{ type: 'summary_text', text: 'thought' }], status: 'completed', encrypted_content: 'E1' },
     { type: 'function_call', call_id: 'call-1', name: 'bash', arguments: '{}' },
-    { type: 'reasoning', encrypted_content: 'E2' },
+    { type: 'reasoning', id: 'rs_2', summary: [{ type: 'summary_text', text: 'thought' }], status: 'completed', encrypted_content: 'E2' },
     { type: 'function_call', call_id: 'call-2', name: 'grep', arguments: '{}' },
   ])
+  // Items captured without optional fields replay with just the required ones.
+  const minimal: ReasoningReplayItem[] = [{ type: 'reasoning', id: 'rs_3', encrypted_content: 'E3' }]
+  assert.deepEqual(
+    toResponsesInput(
+      [message('assistant', [toolCall('call-x', 'bash', '{}')])],
+      undefined,
+      () => minimal,
+    ).input,
+    [
+      { type: 'reasoning', id: 'rs_3', encrypted_content: 'E3' },
+      { type: 'function_call', call_id: 'call-x', name: 'bash', arguments: '{}' },
+    ],
+  )
   // An unknown call id injects nothing.
   const toolOnly = [{ type: 'function_call', call_id: 'call-x', name: 'bash', arguments: '{}' }]
   assert.deepEqual(


### PR DESCRIPTION
描述
背景
Copilot 的 /models 目录持续演进：新增了仅支持 /responses 的模型家族(gpt-5.5/5.6、grok-4.5 等)、按模型声明思考等级(capabilities.supports.reasoning_effort),且部分模型同时暴露两个端点但两个端点的能力并不对等。这三次提交让插件完整跟上这三件事。

主要变更
1. Responses 线路支持，接入 GPT-5.6 系列(3b1c62a)

按目录的 supported_endpoints 为每个模型选择上游协议：仅列 /responses 的模型(gpt-5.6-luna/sol/terra、gpt-5.5 等)走 Responses 线路，其余走 chat completions
新增 CopilotResponsesItemNormalizer:Copilot 网关对同一输出项的每个流式事件都换发新的 opaque item id,按事件序号重写为稳定键，文本分片与整段到达的函数调用参数才能正确拼装
输出上限改用 max_completion_tokens(新模型拒绝旧拼写 max_tokens)
修复 Copilot 网关下 Gemini 模型流式响应的 usage 统计与 reasoning 文本处理
2. 思考等级选择(09bd6c1)

解析目录的 capabilities.supports.reasoning_effort 数组,经 resolveModel 透出,模型选择器出现等级菜单(档位来自实时目录,非硬编码)
请求按线路映射:chat completions 发送顶层 reasoning_effort,Responses 发送 reasoning.effort;目录未声明等级的模型不携带该参数(由框架在 I/O 前拦截)
容错：目录中重复/空串/null 的等级条目会被去重丢弃
3. 双端点模型的请求重路由(c24aa8a)

gpt-5.4、gpt-5-mini 同时声明两个端点，默认走 chat;但 Copilot 在 /chat/completions 上拒绝“函数工具 + 思考等级”组合(400 invalid_request_body)。现在此类请求自动改走 /responses(线上验证：chat 400 → responses 200)
等级为 none 时留在 chat 线路(该组合是允许的)；纯 chat 模型不受影响
修复快照持久化丢字段的隐患:copilotWire 原先重启加载时被静默丢弃，responses-only 模型在 TTL 窗口内会错误回落到 chat 线路；现在 copilotWire/copilotResponses 均随快照存取并严格校验
测试与验证
单元测试 145 项全部通过：新增 Responses 事件拼装、等级映射与容错、重路由全分支、快照 round-trip 等用例
真实 Copilot 订阅线上验证：目录发现(22 个模型，19 个带思考等级)、gpt-5.4 工具+等级请求的双线路对照(chat → 复现 400;responses → 200 流式)
中英文 README 同步更新