### PR TITLE
fix(codex): bound replayed tool call IDs

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -4,7 +4,7 @@
  * endpoint.
  */
 
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { attributionHeaders, EMPTY_RESPONSE_CODE, errorChain, LlmAdapter, LlmError, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type {
   GenerateOptions,
@@ -477,6 +477,56 @@ export interface CodexAdapterOptions {
   speedFor?: (sessionId: string | undefined, model: string) => Promise<boolean> | boolean
 }
 
+const CODEX_CALL_ID_MAX_LENGTH = 64
+const CODEX_CALL_ID_PREFIX = 'call_'
+
+/**
+ * Bound tool-call ids at the Codex wire boundary without changing the shared
+ * Responses translation used by Grok. Short ids stay verbatim. Oversized ids
+ * become deterministic hashes, and every id already present in this request
+ * is reserved first so a generated id cannot collide with a legitimate short
+ * one (or another oversized id).
+ */
+function normalizeCodexCallIds(input: ResponsesRequestInput['input']): ResponsesRequestInput['input'] {
+  const mapping = new Map<string, string>()
+  const used = new Set<string>()
+  const callId = (item: Record<string, unknown>): string | undefined =>
+    (item.type === 'function_call' || item.type === 'function_call_output') && typeof item.call_id === 'string'
+      ? item.call_id
+      : undefined
+
+  for (const item of input) {
+    const id = callId(item)
+    if (id !== undefined && id.length <= CODEX_CALL_ID_MAX_LENGTH) {
+      mapping.set(id, id)
+      used.add(id)
+    }
+  }
+
+  for (const item of input) {
+    const id = callId(item)
+    if (id === undefined || mapping.has(id)) continue
+    let attempt = 0
+    let normalized: string
+    do {
+      const hash = createHash('sha256')
+      if (attempt > 0) hash.update(String(attempt)).update('\0')
+      const digest = hash.update(id).digest('hex')
+      normalized = `${CODEX_CALL_ID_PREFIX}${digest.slice(0, CODEX_CALL_ID_MAX_LENGTH - CODEX_CALL_ID_PREFIX.length)}`
+      attempt += 1
+    } while (used.has(normalized))
+    mapping.set(id, normalized)
+    used.add(normalized)
+  }
+
+  return input.map((item) => {
+    const id = callId(item)
+    if (id === undefined) return item
+    const normalized = mapping.get(id) ?? id
+    return normalized === id ? item : { ...item, call_id: normalized }
+  })
+}
+
 /**
  * The Responses request body for one generation. A fast-tier request (the
  * composer Speed toggle, the codex CLI's fast mode) carries
@@ -491,7 +541,7 @@ export function codexRequestBody(
   return {
     model: options.model,
     instructions: resolved.instructions ?? DEFAULT_CODEX_INSTRUCTIONS,
-    input: resolved.input,
+    input: normalizeCodexCallIds(resolved.input),
     ...options.tools !== undefined && options.tools.length > 0
       ? { tools: toResponsesTools(options.tools) }
       : {},

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -273,6 +273,50 @@ test('codexRequestBody sends service_tier priority only on the fast tier', () =>
   assert.deepEqual(fast.reasoning, { effort: 'high', summary: 'auto' })
 })
 
+test('codexRequestBody bounds tool-call ids without losing their pairings', () => {
+  const short = 'call-short'
+  const sharedPrefix = `call_${'x'.repeat(60)}`
+  const longA = `${sharedPrefix}-a`
+  const longB = `${sharedPrefix}-b`
+  const resolved = {
+    input: [
+      { type: 'function_call', call_id: short, name: 'short', arguments: '{}' },
+      { type: 'function_call_output', call_id: short, output: 'short result' },
+      { type: 'function_call', call_id: longA, name: 'long_a', arguments: '{}' },
+      { type: 'function_call_output', call_id: longA, output: 'long A result' },
+      { type: 'function_call', call_id: longB, name: 'long_b', arguments: '{}' },
+      { type: 'function_call_output', call_id: longB, output: 'long B result' },
+    ],
+  }
+  const options = { provider: 'codex', model: 'gpt-5.1-codex', messages: [] }
+  const first = codexRequestBody(options, resolved, false)
+  const second = codexRequestBody(options, resolved, false)
+  const ids = (first.input as Record<string, unknown>[]).map(item => String(item.call_id))
+
+  assert.equal(ids[0], short)
+  assert.equal(ids[1], short)
+  assert.ok(ids.every(id => id.length <= 64))
+  assert.equal(ids[2], ids[3])
+  assert.equal(ids[4], ids[5])
+  assert.notEqual(ids[2], ids[4])
+  assert.deepEqual(second.input, first.input)
+
+  // A short id that happens to equal the first hash candidate is reserved;
+  // the long id is rehashed rather than associating two calls with one id.
+  const reserved = ids[2]
+  const collision = codexRequestBody(options, {
+    input: [
+      { type: 'function_call', call_id: reserved, name: 'reserved', arguments: '{}' },
+      { type: 'function_call', call_id: longA, name: 'long_a', arguments: '{}' },
+      { type: 'function_call_output', call_id: longA, output: 'long A result' },
+    ],
+  }, false)
+  const collisionIds = (collision.input as Record<string, unknown>[]).map(item => String(item.call_id))
+  assert.equal(collisionIds[0], reserved)
+  assert.equal(collisionIds[1], collisionIds[2])
+  assert.notEqual(collisionIds[1], reserved)
+})
+
 test('modalities: codex and claude declare image input; grok gates text-only models', async () => {
   const codex = codexAdapter({ session: codexSession, discovery: false })
   const codexModels = await codex.listModels('codex')


### PR DESCRIPTION
Closes #29.

## What changed

- Normalize tool-call IDs only when building the Codex request body, leaving the shared Responses translator (and Grok) unchanged.
- Preserve every ID that is already 64 characters or shorter.
- Replace oversized IDs with a deterministic 64-character `call_` + SHA-256 form.
- Apply one request-wide mapping to both `function_call.call_id` and matching `function_call_output.call_id` values, so their association is preserved.
- Reserve legitimate short IDs before allocating hashes and rehash on a collision.

## Why not truncate

Two distinct provider IDs can share their first 64 characters. Simple `.slice(0, 64)` would collapse them and could associate a tool result with the wrong call. Hashing at the outbound Codex boundary also repairs already-persisted histories on their next request without changing DSH's internal `CallId` or another provider's protocol.

## Tests

- `npm test` — 114 passed, 0 failed
- `npm run build` — TypeScript and production client build passed
- Regression coverage verifies short-ID preservation, the 64-character bound, call/result pairing, same-prefix long IDs remaining distinct, repeat determinism, and a forced collision with a legitimate short ID

A credentialed live Codex request was not used; the reported 69-character failure is exercised at the exact request-body boundary, and the reporter's truncation workaround already confirms that respecting the backend limit resolves the 400.