### PR TITLE
fix: support DSH 0.1.1 RC peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-attachment": "^0.1.0-rc.5",
-    "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.5",
-    "@deepseek-ai/dsh-llm": "^0.1.0-rc.5",
-    "@deepseek-ai/dsh-tools": "^0.1.0-rc.5",
+    "@deepseek-ai/dsh-attachment": "^0.1.0-rc.5 || ^0.1.1-rc.2",
+    "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.5 || ^0.1.1-rc.2",
+    "@deepseek-ai/dsh-llm": "^0.1.0-rc.5 || ^0.1.1-rc.2",
+    "@deepseek-ai/dsh-tools": "^0.1.0-rc.5 || ^0.1.1-rc.2",
     "@deepseek-ai/schemastery": "^3.18.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

`dsh-plugin-subscriptions@0.5.1` declares its DSH peers only as `^0.1.0-rc.5`. In an official DSH `0.1.1-rc.2` profile, pnpm therefore resolves a second `@deepseek-ai/dsh-llm@0.1.0-rc.8` for the plugin. That adapter base does not have `prepareCall()`, so every Codex and Claude turn fails before provider I/O with:

```
registration.adapter.prepareCall is not a function
```

## Fix

Declare the current release line for the four shared DSH runtime peers:

```
^0.1.0-rc.5 || ^0.1.1-rc.2
```

This preserves compatibility with the existing rc.5+ line while allowing the plugin to share the host RC.2 runtime instance.

## Validation

Created a clean pnpm resolution fixture with all four peers pinned to `0.1.1-rc.2`. The plugin resolves `@deepseek-ai/dsh-llm` to `0.1.1-rc.2`, and `LlmAdapter.prototype.prepareCall` is a function.