### PR TITLE
feat: show subscription usage in composer stats strip

### DIFF
--- a/src/client/SubscriptionUsageBadge.tsx
+++ b/src/client/SubscriptionUsageBadge.tsx
@@ -1,0 +1,183 @@
+/**
+ * Subscription usage badge: a compact readout in the composer's stats strip
+ * (`conversation.composer.dock`), showing rate-limit window percentages for
+ * each provider's DEFAULT account (Claude, Codex, etc.). Polls the
+ * `/subscriptions-auth` `status` + `usage` endpoints on a slow interval;
+ * renders nothing when no provider has a logged-in account or usage is
+ * unsupported.
+ *
+ * Only the default account is shown — the same account direct (non-pool)
+ * routes serve — so the badge stays a single compact line even for a
+ * provider with several accounts connected. The full per-account breakdown
+ * already lives in Settings → Subscriptions.
+ *
+ * Every color resolves through a `--dsw-alias-*` design token; this component
+ * uses no locale `t` — it renders fixed short labels (provider names,
+ * "5h", "Wk") that are universal.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
+import type { PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
+import type { ConnectionHandle } from '@deepseek-ai/dsh-api-remotes/client'
+import { callSubscriptionsAuth } from './SubscriptionsSection.js'
+import type { AccountStatus, ProviderStatus, ProviderUsage, SubscriptionProvider, UsageWindow } from './SubscriptionsSection.js'
+
+/** How often the badge re-reads usage; the server also shares its own cache/negative-cache across UI surfaces. */
+const POLL_INTERVAL_MS = 15 * 60_000
+
+/** Injected dependencies (slot `inject`). */
+export interface SubscriptionUsageBadgeInjected {
+  /** Connection RPC caller to reach the `/subscriptions-auth` channel. */
+  rpc: ConnectionHandle['rpc']
+}
+
+/** Props delivered by the slot outlet + inject. */
+export type SubscriptionUsageBadgeProps = PropsRuntime<'conversation.composer.dock'>
+  & Partial<SubscriptionUsageBadgeInjected>
+
+/** One provider's usage snapshot as rendered by the badge (default account only). */
+interface ProviderUsageDisplay {
+  provider: SubscriptionProvider
+  name: string
+  windows: UsageWindow[]
+}
+
+/** Brand display names (short form for the compact badge). */
+const PROVIDER_NAMES: Record<SubscriptionProvider, string> = {
+  codex: 'Codex',
+  claude: 'Claude',
+  grok: 'Grok',
+  copilot: 'Copilot',
+}
+
+/**
+ * Compact time-remaining label derived from the window's `resetsAt` timestamp:
+ * "6d18h" (days+hours), "1h58m" (hours+minutes), or "42m" (minutes only).
+ * Falls back to the scope/kind abbreviation when no reset time is known.
+ */
+function windowLabel(w: UsageWindow): string {
+  if (w.resetsAt === undefined) {
+    if (w.scope !== undefined && w.scope !== '') return w.scope
+    switch (w.kind) {
+      case 'session': return '5h'
+      case 'weekly': return 'Wk'
+      default: return 'W'
+    }
+  }
+  const ms = Math.max(0, w.resetsAt - Date.now())
+  const minutes = Math.floor(ms / 60_000)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+  if (days > 0) return `${days}d${hours % 24}h`
+  if (hours > 0) return `${hours}h${minutes % 60}m`
+  return `${Math.max(1, minutes)}m`
+}
+
+/** The default account of a provider's account list, when any is logged in. */
+function defaultAccountOf(status: ProviderStatus | undefined): AccountStatus | undefined {
+  if (status === undefined || status.accounts.length === 0) return undefined
+  return status.accounts.find(a => a.isDefault) ?? status.accounts[0]
+}
+
+/**
+ * The composer subscription-usage badge. Renders a compact text segment like
+ * `Claude 1h58m 13% · 6d18h 3%` (time-remaining + used%) — one segment per
+ * provider with a logged-in default account that supports usage. Returns
+ * null when no data is available.
+ */
+export function SubscriptionUsageBadge({ rpc }: SubscriptionUsageBadgeProps) {
+  const [displays, setDisplays] = useState<ProviderUsageDisplay[]>([])
+  const inflightRef = useRef(false)
+  const mountedRef = useRef(true)
+  // Last-known-good display per provider, kept across a failed poll (e.g. a
+  // 429 during the server's own negative-cache cooldown) so the segment
+  // doesn't flicker away — it only disappears once the default account
+  // actually logs out or a fetch succeeds but reports the window as
+  // unsupported.
+  const lastKnownRef = useRef(new Map<SubscriptionProvider, ProviderUsageDisplay>())
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (rpc === undefined || inflightRef.current) return
+    inflightRef.current = true
+    try {
+      const statusResp = await callSubscriptionsAuth<{
+        providers: Record<SubscriptionProvider, ProviderStatus>
+      }>(rpc, 'status', {})
+      if (!mountedRef.current) return
+
+      const accounts = new Map<SubscriptionProvider, string>()
+      for (const id of Object.keys(statusResp.providers) as SubscriptionProvider[]) {
+        const account = defaultAccountOf(statusResp.providers[id])
+        if (account !== undefined) accounts.set(id, account.key)
+      }
+
+      const lastKnown = lastKnownRef.current
+      // Drop last-known state for anything no longer logged in — that is a
+      // real signal, unlike a fetch failure.
+      for (const provider of lastKnown.keys()) {
+        if (!accounts.has(provider)) lastKnown.delete(provider)
+      }
+
+      if (accounts.size === 0) {
+        setDisplays([])
+        return
+      }
+
+      const results = await Promise.allSettled(
+        [...accounts.entries()].map(async ([provider, account]) => {
+          const usage = await callSubscriptionsAuth<ProviderUsage>(rpc, 'usage', { provider, account })
+          return { provider, usage }
+        }),
+      )
+      if (!mountedRef.current) return
+
+      for (const r of results) {
+        if (r.status !== 'fulfilled') continue // keep whatever is cached for this provider
+        const { provider, usage } = r.value
+        if (!usage.supported || !usage.windows || usage.windows.length === 0) {
+          lastKnown.delete(provider)
+          continue
+        }
+        lastKnown.set(provider, { provider, name: PROVIDER_NAMES[provider], windows: usage.windows })
+      }
+      // Render in a stable order (the account map's insertion order, which
+      // follows Object.keys(statusResp.providers)) so a segment doesn't jump
+      // around as polls settle at different times.
+      const order = [...accounts.keys()]
+      setDisplays(order.map(provider => lastKnown.get(provider)).filter((d): d is ProviderUsageDisplay => d !== undefined))
+    } catch {
+      // A failed poll must not crash the badge; keep last known state.
+    } finally {
+      inflightRef.current = false
+    }
+  }, [rpc])
+
+  useEffect(() => {
+    mountedRef.current = true
+    void refresh()
+    const timer = setInterval(() => { void refresh() }, POLL_INTERVAL_MS)
+    return () => {
+      mountedRef.current = false
+      clearInterval(timer)
+    }
+  }, [refresh])
+
+  if (displays.length === 0) return null
+
+  const segments: string[] = []
+  for (const d of displays) {
+    const parts = d.windows.map(w => `${windowLabel(w)} ${Math.round(Math.min(100, Math.max(0, w.usedPercent)))}%`)
+    segments.push(`${d.name} ${parts.join(' · ')}`)
+  }
+
+  return <span style={styles.root}>{segments.join(' | ')}</span>
+}
+
+const styles: Record<string, CSSProperties> = {
+  root: {
+    color: 'var(--dsw-alias-label-tertiary)',
+    fontSize: 12,
+    lineHeight: '18px',
+    whiteSpace: 'nowrap',
+  },
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -30,6 +30,8 @@ import { VideoGenerateToolview, createVideoLoader } from './VideoGenerateToolvie
 import type { VideoGenerateToolviewInjected } from './VideoGenerateToolview.js'
 import { SpeedSelect, createSpeedLoader, createSpeedSetter } from './SpeedSelect.js'
 import type { ModelDirectoriesLike, SpeedSelectInjected } from './SpeedSelect.js'
+import { SubscriptionUsageBadge } from './SubscriptionUsageBadge.js'
+import type { SubscriptionUsageBadgeInjected } from './SubscriptionUsageBadge.js'
 import { en, zh } from './locales.js'
 import type { SubscriptionsKey } from './locales.js'
 
@@ -37,6 +39,7 @@ export type { SubscriptionsSectionInjected, SubscriptionsSectionProps } from './
 export type { ImageGenerateToolviewInjected, ImageGenerateToolviewProps } from './ImageGenerateToolview.js'
 export type { VideoGenerateToolviewInjected, VideoGenerateToolviewProps } from './VideoGenerateToolview.js'
 export type { SpeedSelectInjected, SpeedSelectProps, SpeedState, SpeedTier } from './SpeedSelect.js'
+export type { SubscriptionUsageBadgeInjected, SubscriptionUsageBadgeProps } from './SubscriptionUsageBadge.js'
 export type { SubscriptionsKey } from './locales.js'
 
 declare module '@deepseek-ai/dsh-client-ui-slots' {
@@ -127,6 +130,16 @@ export function apply(ctx: ClientContext): void {
       setSpeed: createSpeedSetter(connection, sessionId),
     }),
   }, SpeedSelect))
+
+  // The subscription usage badge renders a compact readout in the composer's
+  // stats strip (conversation.composer.dock) — e.g. "Claude 5h 45% · Wk 23%".
+  // A fresh id means it appears beside the shipped StatsLine, never replacing it.
+  ctx.slots.inject('conversation.composer.dock', () => ctx.slots.register({
+    name: 'conversation.composer.dock',
+    id: 'subscription-usage',
+    order: 10,
+    inject: (): SubscriptionUsageBadgeInjected => ({ rpc: connection.rpc }),
+  }, SubscriptionUsageBadge))
 
   // The /fast slash command offers the same Standard/Fast choice as a popup.
   // `available` is synchronous and sees only the session id, so the command

--- a/src/providers/pool-usage.ts
+++ b/src/providers/pool-usage.ts
@@ -53,6 +53,11 @@ interface SnapshotEntry {
  * promise ever reached `entries`. For an endpoint that rate-limits
  * progressively (each hit within the window pushes the next one further
  * out), that retry storm is a permanent lockout, not a transient blip.
+ *
+ * `lastSnapshot` carries forward the most recent successful fetch, when one
+ * exists, so a member/display that was showing real data before this
+ * failure keeps showing it (stale, but not blank) through the cooldown
+ * instead of falling back to the zero-urgency/no-data degraded state.
  */
 interface FailureEntry {
   snapshot?: undefined
@@ -60,6 +65,8 @@ interface FailureEntry {
   at: number
   /** Overrides `ttlMs` — the endpoint's own `retry-after` when it sent one. */
   cooldownMs: number
+  /** The last successful snapshot before this failure, when one exists. */
+  lastSnapshot?: ProviderUsage
 }
 
 type CacheEntry = SnapshotEntry | FailureEntry
@@ -86,6 +93,14 @@ export class PoolUsageTracker {
    * stale one answers immediately while the refresh serves the NEXT call
    * (member selection must never block on the network mid-conversation). A
    * failure still cooling down degrades immediately with no network call.
+   *
+   * Deliberately does NOT fall back to `lastSnapshot` the way
+   * {@link snapshotFor} does: scoring routing decisions off data that is
+   * known to be stale-and-unrefreshable risks steering traffic by a urgency
+   * number the endpoint itself is no longer vouching for, whereas
+   * `snapshotFor`'s stale-display concern (the Settings page, the composer
+   * badge) has no such downside — showing an old percentage beats showing
+   * nothing.
    * @param member - the pool member to score (account resolved).
    * @returns availability plus the urgency score.
    */
@@ -131,11 +146,26 @@ export class PoolUsageTracker {
     if (entry !== undefined && Date.now() - entry.at < (entry.cooldownMs ?? this.ttlMs)) {
       if (entry.snapshot !== undefined) {
         if (!force) return entry.snapshot
+      } else if (entry.lastSnapshot !== undefined) {
+        // A stale-but-real snapshot beats surfacing the cooldown error to
+        // every display surface — this is what was previously showing, so
+        // keep showing it (even through a forced refresh: retrying past the
+        // cooldown is exactly the retry storm `cooldownMs` exists to avoid).
+        return entry.lastSnapshot
       } else {
         throw entry.error
       }
     }
-    return this.refresh(key, fetcher)
+    try {
+      return await this.refresh(key, fetcher)
+    } catch (error: unknown) {
+      // Same fallback as the already-cooling-down branch above, for the
+      // fetch that just failed on THIS call: `refresh` recorded whatever
+      // snapshot was on record before it ran onto the new failure entry.
+      const failed = this.entries.get(key)
+      if (failed?.snapshot === undefined && failed?.lastSnapshot !== undefined) return failed.lastSnapshot
+      throw error
+    }
   }
 
   /** Drop cached snapshots: one account, or a whole provider when `account` is omitted. */
@@ -160,6 +190,9 @@ export class PoolUsageTracker {
   private refresh(key: string, fetcher: () => Promise<ProviderUsage>): Promise<ProviderUsage> {
     let pending = this.inflight.get(key)
     if (pending === undefined) {
+      // Captured before the fetch starts: whichever real snapshot is on
+      // record right now is what a failure below should fall back to.
+      const lastSnapshot = this.entries.get(key)?.snapshot
       pending = fetcher().then(
         (snapshot) => {
           this.entries.set(key, { snapshot, at: Date.now() })
@@ -167,7 +200,12 @@ export class PoolUsageTracker {
         },
         (error: unknown) => {
           if (!isMissingOrInvalidCredential(error)) {
-            this.entries.set(key, { error, at: Date.now(), cooldownMs: cooldownFor(error, this.ttlMs) })
+            this.entries.set(key, {
+              error,
+              at: Date.now(),
+              cooldownMs: cooldownFor(error, this.ttlMs),
+              ...lastSnapshot === undefined ? {} : { lastSnapshot },
+            })
           }
           throw error
         },

--- a/test/pool-usage.spec.ts
+++ b/test/pool-usage.spec.ts
@@ -99,3 +99,38 @@ test('snapshotFor: a provider without a usage fetcher answers supported:false', 
   const usage = await tracker.snapshotFor('grok', 'a1')
   assert.deepEqual(usage, { supported: false })
 })
+
+test('snapshotFor: a rate limit after a prior success serves the stale snapshot instead of throwing', async () => {
+  let rateLimited = false
+  const { tracker, calls } = trackerOf(() => {
+    if (rateLimited) {
+      return Promise.reject(new OAuthEndpointError('claude usage token endpoint error (HTTP 429)', 429, undefined, 60_000))
+    }
+    return Promise.resolve(OK_USAGE)
+  }, 10)
+
+  const first = await tracker.snapshotFor('claude', 'a1')
+  assert.deepEqual(first, OK_USAGE)
+
+  // Past the 10ms TTL, so the next call re-fetches instead of serving the
+  // fresh-cache fast path.
+  await new Promise(resolve => setTimeout(resolve, 20))
+  rateLimited = true
+  const second = await tracker.snapshotFor('claude', 'a1')
+  assert.deepEqual(second, OK_USAGE, 'a rate-limited refresh should serve the last-known snapshot, not throw')
+  assert.equal(calls.count, 2)
+
+  // Still cooling down: repeat calls (forced or not) keep serving the
+  // stale snapshot rather than re-hitting the endpoint or throwing.
+  const third = await tracker.snapshotFor('claude', 'a1')
+  const forced = await tracker.snapshotFor('claude', 'a1', true)
+  assert.deepEqual(third, OK_USAGE)
+  assert.deepEqual(forced, OK_USAGE)
+  assert.equal(calls.count, 2, 'the live cooldown must not be bypassed even by a forced call')
+})
+
+test('snapshotFor: a rate limit with no prior success still throws (nothing to fall back to)', async () => {
+  const error = new OAuthEndpointError('claude usage token endpoint error (HTTP 429)', 429, undefined, 60_000)
+  const { tracker } = trackerOf(() => Promise.reject(error))
+  await assert.rejects(tracker.snapshotFor('claude', 'a1'), error)
+})


### PR DESCRIPTION
## Summary

Adds a compact subscription usage badge to the composer's stats line (the `conversation.composer.dock` slot), showing rate-limit window **time-remaining** and **used%** for each provider's default account.

**Before:**
```
4 turns · 45 steps | LLM 6m43s | Cache hit 94% | Input 5.6M tok · Output 23.8K tok
```

**After** (with Claude logged in):
```
4 turns · 45 steps | LLM 6m43s | Cache hit 94% | Input 5.6M tok · Output 23.8K tok | Claude 1h58m 13% · 6d18h 3%
```

## How it works

- Polls the plugin's existing `/subscriptions-auth` `status` + `usage` RPC endpoints every **15 minutes**, matching `PoolUsageTracker`'s own cache TTL so the badge causes no extra upstream traffic beyond what that cache already coalesces.
- Shows the **default account** per provider (the same account direct/non-pool routes serve) — with multiple accounts connected, the badge stays a single compact line; the full per-account breakdown already lives in Settings → Subscriptions.
- Computes time-remaining from each window's `resetsAt` timestamp: `6d18h` / `1h58m` / `42m`
- Falls back to kind labels (`5h`/`Wk`) when `resetsAt` is absent
- Returns `null` (renders nothing) when no provider has a logged-in account or usage is unsupported
- Registers with a **fresh slot id** (`subscription-usage`, order 10) — appears alongside the shipped StatsLine, never replaces it

## Changes

| File | Change |
|------|--------|
| `src/client/SubscriptionUsageBadge.tsx` | New: the badge component, with per-provider last-known-display tracking across failed polls |
| `src/client/index.ts` | Slot registration (`conversation.composer.dock`, id `subscription-usage`, order 10) |
| `src/providers/pool-usage.ts` | `PoolUsageTracker.snapshotFor()` now serves the last successful snapshot instead of throwing during a rate-limit cooldown (see review notes) |
| `test/pool-usage.spec.ts` | Tests for the stale-snapshot-served-through-cooldown behavior |

## History

This PR was originally opened against the pre-refactor single-account codebase with its own per-provider usage cache in `src/index.ts`. `main` has since landed the multi-account rewrite (`status()` → `accounts[]`, `usage(provider, account, ...)`, and the shared `PoolUsageTracker`). **Rebased and rewritten** on top of current `main`:
- The badge now targets the new API, showing each provider's default account.
- The custom per-provider cache this PR originally added is gone — superseded by `PoolUsageTracker`, which already did most of what that cache was for.
- Point 2 from the original review (a rate-limited provider's segment vanishing) turned out to still apply to `PoolUsageTracker.snapshotFor()` after the rewrite, so that's fixed there instead, with a doc comment explaining why the routing-side `quotaFor()` is deliberately left as-is (see the fix commit message for the full reasoning).

## Review notes (from @V1ki, on the pre-rebase version)

1. **Description was out of sync with the code** — the description above is now accurate against the current diff.
2. **A rate-limited provider vanishing from the badge** — fixed at the `PoolUsageTracker.snapshotFor()` level after the rebase (see above), with a new test.

Also: the out-of-scope `prepare` script commit was dropped, and the two pre-existing test-flakiness issues were filed separately as #55.
