### PR TITLE
fix(codex): reconcile orphaned tool-call outputs before dispatch

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -544,6 +544,41 @@ function normalizeCodexCallIds(input: ResponsesRequestInput['input']): Responses
   })
 }
 
+/** Text marking a repaired tool output as an unknown outcome; the model must verify before retrying. */
+export const CODEX_UNKNOWN_TOOL_OUTCOME = 'The tool call has no recorded result. Its outcome is unknown; verify external state before retrying any operation that may have side effects.'
+
+/**
+ * Reconcile one Responses input's tool-call pairing after id normalization:
+ * every `function_call` gets an output and every `function_call_output`
+ * matches a call. Missing outputs become error-style outputs whose text marks
+ * the outcome unknown; orphan outputs are dropped. Duplicate calls of one id
+ * receive exactly one repair output. The request is local repair only: the
+ * durable history stays authoritative and unchanged.
+ * @param input - normalized Responses input items.
+ * @returns the same array when already balanced, otherwise a repaired array.
+ */
+export function reconcileResponsesToolCalls(input: ResponsesRequestInput['input']): ResponsesRequestInput['input'] {
+  const calls = new Set<string>()
+  const outputs = new Set<string>()
+  for (const item of input) {
+    if (item.type === 'function_call' && typeof item.call_id === 'string') calls.add(item.call_id)
+    else if (item.type === 'function_call_output' && typeof item.call_id === 'string') outputs.add(item.call_id)
+  }
+  const missing = new Set([...calls].filter(callId => !outputs.has(callId)))
+  if (missing.size === 0 && [...outputs].every(callId => calls.has(callId))) return input
+  const balanced: ResponsesRequestInput['input'] = []
+  for (const item of input) {
+    if (item.type === 'function_call_output' && (typeof item.call_id !== 'string' || !calls.has(item.call_id))) {
+      continue
+    }
+    balanced.push(item)
+    if (item.type === 'function_call' && typeof item.call_id === 'string' && missing.delete(item.call_id)) {
+      balanced.push({ type: 'function_call_output', call_id: item.call_id, output: CODEX_UNKNOWN_TOOL_OUTCOME })
+    }
+  }
+  return balanced
+}
+
 /**
  * The Responses request body for one generation. A fast-tier request (the
  * composer Speed toggle, the codex CLI's fast mode) carries
@@ -558,7 +593,7 @@ export function codexRequestBody(
   return {
     model: options.model,
     instructions: resolved.instructions ?? DEFAULT_CODEX_INSTRUCTIONS,
-    input: normalizeCodexCallIds(resolved.input),
+    input: reconcileResponsesToolCalls(normalizeCodexCallIds(resolved.input)),
     ...options.tools !== undefined && options.tools.length > 0
       ? { tools: toResponsesTools(options.tools) }
       : {},

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -318,6 +318,43 @@ test('codexRequestBody sends service_tier priority only on the fast tier', () =>
   assert.deepEqual(fast.reasoning, { effort: 'high', summary: 'auto' })
 })
 
+test('codexRequestBody reconciles orphaned tool calls before dispatch', () => {
+  const missing = codexRequestBody(
+    { provider: 'codex', model: 'gpt-5.6-sol', messages: [] },
+    {
+      input: [
+        { type: 'function_call', call_id: 'call-missing', name: 'lookup', arguments: '{}' },
+        { type: 'function_call_output', call_id: 'call-orphan', output: 'stale' },
+        { type: 'function_call', call_id: 'call-ok', name: 'read', arguments: '{}' },
+        { type: 'function_call_output', call_id: 'call-ok', output: 'done' },
+      ],
+    },
+    false,
+  )
+  const input = missing.input as Record<string, unknown>[]
+  assert.equal(input.length, 4)
+  assert.equal(input[0].type, 'function_call')
+  assert.equal(input[0].call_id, 'call-missing')
+  assert.equal(input[1].type, 'function_call_output')
+  assert.equal(input[1].call_id, 'call-missing')
+  assert.match(String(input[1].output), /outcome is unknown/)
+  assert.equal(input[2].call_id, 'call-ok')
+  assert.equal(input[3].type, 'function_call_output')
+  assert.equal(input[3].call_id, 'call-ok')
+
+  const balanced = codexRequestBody(
+    { provider: 'codex', model: 'gpt-5.6-sol', messages: [] },
+    {
+      input: [
+        { type: 'function_call', call_id: 'call-1', name: 'lookup', arguments: '{}' },
+        { type: 'function_call_output', call_id: 'call-1', output: 'done' },
+      ],
+    },
+    false,
+  )
+  assert.equal((balanced.input as Record<string, unknown>[]).length, 2)
+})
+
 test('codexRequestBody bounds tool-call ids without losing their pairings', () => {
   const short = 'call-short'
   const sharedPrefix = `call_${'x'.repeat(60)}`
@@ -355,9 +392,13 @@ test('codexRequestBody bounds tool-call ids without losing their pairings', () =
     ],
   }, false)
   const collisionIds = (collision.input as Record<string, unknown>[]).map(item => String(item.call_id))
+  // The orphaned reserved call now carries a repaired output of its own, so
+  // the id pairs are [reserved, reserved] then [hash, hash] instead of the
+  // pre-repair adjacency [reserved, hash, hash].
   assert.equal(collisionIds[0], reserved)
-  assert.equal(collisionIds[1], collisionIds[2])
-  assert.notEqual(collisionIds[1], reserved)
+  assert.equal(collisionIds[1], reserved)
+  assert.equal(collisionIds[2], collisionIds[3])
+  assert.notEqual(collisionIds[0], collisionIds[2])
 })
 
 /** One text-only message of any role, for request-body assembly. */


### PR DESCRIPTION
## Problem

Long tool-heavy sessions on the `codex` provider (e.g. `gpt-5.6-sol`) can become permanently stuck: every later request fails with

```
codex API error (HTTP 400): { "error": { "message": "No tool output found for function call call_5nOH8w...", "type": "invalid_request_error", "param": "input" } }
```

Once the imbalanced history exists, the error repeats on every subsequent Codex turn — even after switching to another model and back — because the same durable history re-serializes into the same invalid `input`. Other providers (Claude, Grok) keep working because they serialize the history differently.

Root cause: the serialized Responses `input` can contain a `function_call` whose `function_call_output` is missing (interrupted execution, compaction, or cross-model replay), or an output without a call. The Codex backend rejects the whole request.

## Fix

`codexRequestBody` now reconciles the tool-call pairing after call-id normalization via `reconcileResponsesToolCalls`:

- every `function_call` without a matching `function_call_output` gets an explicit output inserted right after the call; its text marks the outcome as **unknown**, so the model verifies external state before retrying side-effecting operations
- `function_call_output` items whose call is absent are dropped
- already balanced inputs are returned unchanged (identity preserved)
- the durable session history is not modified; the repair is request-local

## Testing

- New test `codexRequestBody reconciles orphaned tool calls before dispatch` covers a call with a missing output and an orphan output
- The existing id-normalization test was updated for the new adjacency: an orphaned call now carries its own repaired output, so pairs are `[reserved, reserved]` then `[hash, hash]`
- 56 focused tests pass (`tsc -p tsconfig.test.json && node --test lib-test/test/`)

## Live verification

- Environment: dsh 0.1.1-rc.2, plugin 0.5.3
- A session that had been failing with the exact 400 above resumed normally after this change; subsequent requests showed fully paired inputs


Fixes the reported `No tool output found for function call` session block on the Codex route.