### PR TITLE
fix: negative-cache pool usage failures, respect 429 retry-after

### DIFF
--- a/src/auth/rpc.ts
+++ b/src/auth/rpc.ts
@@ -120,10 +120,12 @@ export interface AuthController {
   /**
    * Current subscription usage of one account.
    * @param signal - caller cancellation from the RPC transport.
+   * @param force - bypass a fresh cached snapshot for an honest re-check
+   *   (the manual Refresh button); a live failure cooldown still applies.
    * @returns `{ supported: false }` when the provider has no usage endpoint.
    * @throws when logged out or the usage lookup fails.
    */
-  usage(provider: ProviderId, account: string, signal: AbortSignal): Promise<ProviderUsage>
+  usage(provider: ProviderId, account: string, signal: AbortSignal, force?: boolean): Promise<ProviderUsage>
   /**
    * Read one image attachment's bytes for inline display.
    * @param ref - the full durable reference (`readImage` verifies against it).
@@ -240,6 +242,15 @@ function readVideoName(payload: unknown): string {
     throw new BadRequest('payload.name must be a bare .mp4 file name')
   }
   return name
+}
+
+/** Validate the `usage` endpoint's optional force flag. */
+function readForce(payload: unknown): boolean {
+  if (typeof payload !== 'object' || payload === null) return false
+  const force = (payload as Record<string, unknown>).force
+  if (force === undefined) return false
+  if (typeof force !== 'boolean') throw new BadRequest('payload.force must be a boolean when present')
+  return force
 }
 
 /** Validate the session id both speed endpoints carry. */
@@ -365,7 +376,7 @@ async function dispatch(
     }
     case 'usage': {
       const provider = readProvider(payload)
-      return ok(await controller.usage(provider, readString(payload, 'account'), signal))
+      return ok(await controller.usage(provider, readString(payload, 'account'), signal, readForce(payload)))
     }
     case 'image':
       return ok(await controller.readImage(readImageRef(payload), signal))

--- a/src/client/SubscriptionsSection.tsx
+++ b/src/client/SubscriptionsSection.tsx
@@ -446,13 +446,13 @@ export function SubscriptionsSection(props: SubscriptionsSectionProps) {
     }
   }, [refresh, startPolling])
 
-  const loadUsage = useCallback(async (provider: SubscriptionProvider, account: string): Promise<void> => {
+  const loadUsage = useCallback(async (provider: SubscriptionProvider, account: string, force = false): Promise<void> => {
     const key = `${provider}:${account}`
     if (rpc === undefined || usageInflightRef.current.has(key)) return
     usageInflightRef.current.add(key)
     setUsageLoading(prev => ({ ...prev, [key]: true }))
     try {
-      const usage = await callSubscriptionsAuth<ProviderUsage>(rpc, 'usage', { provider, account })
+      const usage = await callSubscriptionsAuth<ProviderUsage>(rpc, 'usage', { provider, account, ...force ? { force: true } : {} })
       if (!mountedRef.current) return
       setUsages(prev => ({ ...prev, [key]: usage }))
       setUsageErrors((prev) => {
@@ -751,7 +751,7 @@ export function SubscriptionsSection(props: SubscriptionsSectionProps) {
                           type="button"
                           style={{ ...styles.usageRefresh, ...usageLoading[usageKey] === true ? { opacity: 0.5, cursor: 'default' } : {} }}
                           disabled={usageLoading[usageKey] === true}
-                          onClick={() => { void loadUsage(id, account.key) }}
+                          onClick={() => { void loadUsage(id, account.key, true) }}
                         >
                           {t('usageRefresh')}
                         </button>

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,12 +298,21 @@ export class SubscriptionsAuthController implements AuthController {
      * plugin itself always uses the default.
      */
     private readonly readClaudeCreds: () => ClaudeSession | undefined = readClaudeCodeCredentials,
+    /**
+     * The pool's usage cache, when the pool is enabled. Routing `usage`
+     * through it (instead of the raw fetcher) means the Settings page shares
+     * the same negative cache as `quota_aware` selection — reopening the
+     * page can no longer re-hit an endpoint that is still cooling down from
+     * a 429.
+     */
+    private readonly poolUsage: PoolUsageTracker | undefined = undefined,
   ) {}
 
-  usage(provider: ProviderId, account: string, signal: AbortSignal): Promise<ProviderUsage> {
+  usage(provider: ProviderId, account: string, signal: AbortSignal, force = false): Promise<ProviderUsage> {
     const fetcher = this.usageFetchers[provider]
     if (fetcher === undefined) return Promise.resolve({ supported: false })
-    return fetcher(account, signal)
+    if (this.poolUsage === undefined) return fetcher(account, signal)
+    return this.poolUsage.snapshotFor(provider, account, force)
   }
 
   async readImage(ref: ImageAttachmentRef, signal: AbortSignal): Promise<ImageBytesResult> {
@@ -818,7 +827,9 @@ export function apply(ctx: Context, config: Config): void {
       else speedBySession.set(sessionId, tier)
     },
   }
-  registerAuthRpc(ctx, new SubscriptionsAuthController(flows, deviceFlows, authChanged, resolveAttachments, usageFetchers), speed, {
+  registerAuthRpc(ctx, new SubscriptionsAuthController(
+    flows, deviceFlows, authChanged, resolveAttachments, usageFetchers, undefined, poolUsage,
+  ), speed, {
     get: () => proxyGetConfig(),
     set: input => proxySetConfig(input),
     test: payload => proxyTestConnection(payload.url, payload.proxy),

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -101,16 +101,23 @@ export async function httpLlmError(response: Response, label: string): Promise<L
   else if (response.status === 408 || response.status === 504) code = 'TIMEOUT'
   else if (response.status >= 500) code = 'SERVER'
   else code = `HTTP_${String(response.status)}`
-  const retryAfter = response.headers.get('retry-after')
-  let providerRetryAfterMs: number | undefined
-  if (retryAfter !== null) {
-    const seconds = Number(retryAfter)
-    if (Number.isFinite(seconds) && seconds > 0) providerRetryAfterMs = seconds * 1000
-  }
+  const providerRetryAfterMs = parseRetryAfterMs(response)
   return new LlmError(message, code, {
     status: response.status,
     ...providerRetryAfterMs === undefined ? {} : { providerRetryAfterMs },
   })
+}
+
+/**
+ * Parse a response's `retry-after` header (seconds) into milliseconds.
+ * @param response - the failed response.
+ * @returns the delay in ms, or undefined when absent/unusable.
+ */
+function parseRetryAfterMs(response: Response): number | undefined {
+  const retryAfter = response.headers.get('retry-after')
+  if (retryAfter === null) return undefined
+  const seconds = Number(retryAfter)
+  return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : undefined
 }
 
 /** An idle watchdog: aborts its signal when no SSE activity arrives within the timeout. */
@@ -186,12 +193,21 @@ export class OAuthEndpointError extends Error {
   readonly status: number
   /** The provider's OAuth `error` code (e.g. `invalid_grant`), when present. */
   readonly oauthCode: string | undefined
+  /**
+   * The endpoint's `retry-after`, in ms, when it sent one. Usage/models
+   * endpoints reuse this error type and can rate-limit progressively (each
+   * hit within the window extends the next one), so a caller retrying on a
+   * fixed schedule instead of honoring this can keep an account locked out
+   * indefinitely.
+   */
+  readonly retryAfterMs: number | undefined
 
-  constructor(message: string, status: number, oauthCode?: string) {
+  constructor(message: string, status: number, oauthCode?: string, retryAfterMs?: number) {
     super(message)
     this.name = 'OAuthEndpointError'
     this.status = status
     this.oauthCode = oauthCode
+    this.retryAfterMs = retryAfterMs
   }
 }
 
@@ -214,7 +230,7 @@ export async function oauthEndpointError(response: Response, label: string): Pro
   const message = detail.length > 0
     ? `${label} token endpoint error (HTTP ${String(response.status)}): ${detail}`
     : `${label} token endpoint error (HTTP ${String(response.status)})`
-  return new OAuthEndpointError(message, response.status, oauthCode)
+  return new OAuthEndpointError(message, response.status, oauthCode, parseRetryAfterMs(response))
 }
 
 /** A session fresh enough to serve a request without a refresh. */

--- a/src/providers/pool-usage.ts
+++ b/src/providers/pool-usage.ts
@@ -11,7 +11,7 @@
  * over time converges on every window hitting zero right at its reset.
  */
 
-import { isMissingOrInvalidCredential } from './common.js'
+import { isMissingOrInvalidCredential, OAuthEndpointError } from './common.js'
 import type { ProviderUsage, UsageWindow } from './common.js'
 import type { ProviderId } from '../auth/store.js'
 import type { ConcretePoolMember } from './pool-family.js'
@@ -38,10 +38,31 @@ export interface MemberQuota {
   fetchedAt: number
 }
 
-interface UsageEntry {
+/** A successful snapshot, cached until `ttlMs` (or the entry's own `cooldownMs`) elapses. */
+interface SnapshotEntry {
   snapshot: ProviderUsage
+  error?: undefined
   at: number
+  cooldownMs?: undefined
 }
+
+/**
+ * A cached fetch failure — the negative-cache counterpart of {@link SnapshotEntry}.
+ * Without this, a failing endpoint (a 429, a timeout) is retried on every
+ * single `quotaFor`/`snapshotFor` call, since nothing about a rejected
+ * promise ever reached `entries`. For an endpoint that rate-limits
+ * progressively (each hit within the window pushes the next one further
+ * out), that retry storm is a permanent lockout, not a transient blip.
+ */
+interface FailureEntry {
+  snapshot?: undefined
+  error: unknown
+  at: number
+  /** Overrides `ttlMs` — the endpoint's own `retry-after` when it sent one. */
+  cooldownMs: number
+}
+
+type CacheEntry = SnapshotEntry | FailureEntry
 
 /**
  * Per-ACCOUNT usage snapshots with in-flight dedupe and
@@ -52,7 +73,7 @@ interface UsageEntry {
  * tracking on their first score.
  */
 export class PoolUsageTracker {
-  private readonly entries = new Map<string, UsageEntry>()
+  private readonly entries = new Map<string, CacheEntry>()
   private readonly inflight = new Map<string, Promise<ProviderUsage>>()
 
   constructor(
@@ -63,7 +84,8 @@ export class PoolUsageTracker {
   /**
    * The quota view of one member. A cold cache awaits the first fetch; a
    * stale one answers immediately while the refresh serves the NEXT call
-   * (member selection must never block on the network mid-conversation).
+   * (member selection must never block on the network mid-conversation). A
+   * failure still cooling down degrades immediately with no network call.
    * @param member - the pool member to score (account resolved).
    * @returns availability plus the urgency score.
    */
@@ -72,25 +94,48 @@ export class PoolUsageTracker {
     const fetcher = this.fetcherFor(member.provider, member.account)
     if (fetcher === undefined) return { available: true, urgency: 0, fetchedAt: 0 }
     const entry = this.entries.get(key)
-    if (entry !== undefined && Date.now() - entry.at < this.ttlMs) {
-      return this.score(member, entry)
-    }
     if (entry !== undefined) {
-      void this.refresh(key, fetcher).catch(() => undefined)
-      return this.score(member, entry)
+      const fresh = Date.now() - entry.at < (entry.cooldownMs ?? this.ttlMs)
+      if (entry.snapshot !== undefined) {
+        if (!fresh) void this.refresh(key, fetcher).catch(() => undefined)
+        return this.score(member, entry)
+      }
+      if (fresh) return degradedQuota(entry.error)
+      // The cooldown expired: fall through to a fresh, blocking attempt.
     }
     try {
       const snapshot = await this.refresh(key, fetcher)
       return this.score(member, { snapshot, at: Date.now() })
     } catch (error: unknown) {
-      // Logged out: the member cannot serve at all. Any other failure
-      // (network, endpoint rate limit) must not block routing — the member
-      // stays available with a zero score, degrading the strategy to plain
-      // priority order for it.
-      return isMissingOrInvalidCredential(error)
-        ? { available: false, urgency: 0, fetchedAt: 0 }
-        : { available: true, urgency: 0, fetchedAt: 0 }
+      return degradedQuota(error)
     }
+  }
+
+  /**
+   * Same cache as {@link quotaFor}, for direct display (the Settings page):
+   * the raw snapshot, or the original fetch error, instead of a routing
+   * score.
+   * @param provider - the account's provider.
+   * @param account - the account key.
+   * @param force - bypass a fresh cached SNAPSHOT for an honest re-check (the
+   *   manual Refresh button). A live failure cooldown is never bypassed —
+   *   retrying through it is exactly what turns a 429 into a permanent
+   *   lockout, so even a forced call still answers from the negative cache.
+   * @returns `{ supported: false }` when the provider has no usage fetcher.
+   */
+  async snapshotFor(provider: ProviderId, account: string, force = false): Promise<ProviderUsage> {
+    const fetcher = this.fetcherFor(provider, account)
+    if (fetcher === undefined) return { supported: false }
+    const key = `${provider}/${account}`
+    const entry = this.entries.get(key)
+    if (entry !== undefined && Date.now() - entry.at < (entry.cooldownMs ?? this.ttlMs)) {
+      if (entry.snapshot !== undefined) {
+        if (!force) return entry.snapshot
+      } else {
+        throw entry.error
+      }
+    }
+    return this.refresh(key, fetcher)
   }
 
   /** Drop cached snapshots: one account, or a whole provider when `account` is omitted. */
@@ -104,14 +149,29 @@ export class PoolUsageTracker {
     }
   }
 
-  /** Run (or join) the single in-flight fetch for one account key. */
+  /**
+   * Run (or join) the single in-flight fetch for one account key, caching
+   * either outcome. A missing/invalid credential is deliberately NOT
+   * negative-cached: it costs no network round trip (the session lookup
+   * fails before the request goes out) and re-checking live means the
+   * member rejoins routing the instant its login is fixed, rather than
+   * waiting out a stale cooldown.
+   */
   private refresh(key: string, fetcher: () => Promise<ProviderUsage>): Promise<ProviderUsage> {
     let pending = this.inflight.get(key)
     if (pending === undefined) {
-      pending = fetcher().then((snapshot) => {
-        this.entries.set(key, { snapshot, at: Date.now() })
-        return snapshot
-      }).finally(() => {
+      pending = fetcher().then(
+        (snapshot) => {
+          this.entries.set(key, { snapshot, at: Date.now() })
+          return snapshot
+        },
+        (error: unknown) => {
+          if (!isMissingOrInvalidCredential(error)) {
+            this.entries.set(key, { error, at: Date.now(), cooldownMs: cooldownFor(error, this.ttlMs) })
+          }
+          throw error
+        },
+      ).finally(() => {
         this.inflight.delete(key)
       })
       this.inflight.set(key, pending)
@@ -120,7 +180,7 @@ export class PoolUsageTracker {
   }
 
   /** Score one member against a snapshot's windows. */
-  private score(member: ConcretePoolMember, entry: UsageEntry): MemberQuota {
+  private score(member: ConcretePoolMember, entry: SnapshotEntry): MemberQuota {
     const windows = (entry.snapshot.windows ?? []).filter(window => windowApplies(window, member.model))
     let available = true
     let urgency = 0
@@ -130,6 +190,23 @@ export class PoolUsageTracker {
     }
     return { available, urgency, fetchedAt: entry.at }
   }
+}
+
+/**
+ * The routing view of a fetch failure. Logged out: the member cannot serve
+ * at all. Any other failure (network, endpoint rate limit) must not block
+ * routing — the member stays available with a zero score, degrading the
+ * strategy to plain priority order for it.
+ */
+function degradedQuota(error: unknown): MemberQuota {
+  return isMissingOrInvalidCredential(error)
+    ? { available: false, urgency: 0, fetchedAt: 0 }
+    : { available: true, urgency: 0, fetchedAt: 0 }
+}
+
+/** How long to hold a failure in the negative cache: the endpoint's own `retry-after`, or the default TTL. */
+function cooldownFor(error: unknown, defaultTtlMs: number): number {
+  return error instanceof OAuthEndpointError && error.retryAfterMs !== undefined ? error.retryAfterMs : defaultTtlMs
 }
 
 /**

--- a/test/pool-usage.spec.ts
+++ b/test/pool-usage.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * PoolUsageTracker's negative cache: a fetch failure must gate retries the
+ * same way a success does, or a progressively rate-limited usage endpoint
+ * (Anthropic's `/oauth/usage`: 429 with a `retry-after` that grows on every
+ * hit inside the window) never gets a chance to recover — see upstream
+ * issue #46. Credential failures are the one exception: they cost no
+ * network round trip and must stay live so a fixed login rejoins instantly.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { LlmError } from '@deepseek-ai/dsh-llm'
+import { OAuthEndpointError } from '../src/providers/common.js'
+import type { ProviderUsage } from '../src/providers/common.js'
+import { PoolUsageTracker } from '../src/providers/pool-usage.js'
+import type { ProviderId } from '../src/auth/store.js'
+
+const MEMBER = { provider: 'claude' as const, account: 'a1', model: 'claude-opus-5' }
+
+const OK_USAGE: ProviderUsage = { supported: true, windows: [{ kind: 'session', usedPercent: 10 }] }
+
+/** A tracker whose sole fetcher counts calls and answers from a script. */
+function trackerOf(
+  fetcher: () => Promise<ProviderUsage>,
+  ttlMs?: number,
+): { tracker: PoolUsageTracker; calls: { count: number } } {
+  const calls = { count: 0 }
+  const tracker = new PoolUsageTracker(
+    (provider: ProviderId, account: string) =>
+      provider === MEMBER.provider && account === MEMBER.account
+        ? () => { calls.count += 1; return fetcher() }
+        : undefined,
+    ttlMs,
+  )
+  return { tracker, calls }
+}
+
+test('quotaFor: a 429 with retry-after is cached — the second call within the window skips the network', async () => {
+  const error = new OAuthEndpointError('claude usage token endpoint error (HTTP 429)', 429, undefined, 60_000)
+  const { tracker, calls } = trackerOf(() => Promise.reject(error))
+  const first = await tracker.quotaFor(MEMBER)
+  assert.deepEqual(first, { available: true, urgency: 0, fetchedAt: 0 })
+  const second = await tracker.quotaFor(MEMBER)
+  assert.deepEqual(second, { available: true, urgency: 0, fetchedAt: 0 })
+  assert.equal(calls.count, 1, 'the cooling-down failure must not be retried')
+})
+
+test('quotaFor: a failure with no retry-after falls back to the default TTL', async () => {
+  const { tracker, calls } = trackerOf(() => Promise.reject(new Error('network blip')), 50)
+  await tracker.quotaFor(MEMBER)
+  await tracker.quotaFor(MEMBER)
+  assert.equal(calls.count, 1, 'still within the default TTL')
+  await new Promise(resolve => setTimeout(resolve, 60))
+  await tracker.quotaFor(MEMBER)
+  assert.equal(calls.count, 2, 'the TTL expired, so this call retries')
+})
+
+test('quotaFor: a missing/invalid credential is never negative-cached, so recovery is immediate', async () => {
+  let broken = true
+  const { tracker, calls } = trackerOf(() =>
+    broken ? Promise.reject(new LlmError('logged out', 'MISSING_CREDENTIAL')) : Promise.resolve(OK_USAGE))
+  const first = await tracker.quotaFor(MEMBER)
+  assert.deepEqual(first, { available: false, urgency: 0, fetchedAt: 0 })
+  broken = false
+  const second = await tracker.quotaFor(MEMBER)
+  assert.equal(second.available, true)
+  assert.equal(calls.count, 2, 'every call re-checks credentials live, no cooldown')
+})
+
+test('quotaFor: a stale success still serves cached data while a background refresh runs', async () => {
+  const { tracker, calls } = trackerOf(() => Promise.resolve(OK_USAGE), 10)
+  await tracker.quotaFor(MEMBER)
+  await new Promise(resolve => setTimeout(resolve, 20))
+  const stale = await tracker.quotaFor(MEMBER)
+  assert.equal(stale.available, true)
+  await new Promise(resolve => setTimeout(resolve, 20))
+  assert.equal(calls.count, 2, 'the stale read triggered exactly one background refresh')
+})
+
+test('snapshotFor: a live failure cooldown is never bypassed, even by a forced (manual refresh) call', async () => {
+  const error = new OAuthEndpointError('claude usage token endpoint error (HTTP 429)', 429, undefined, 60_000)
+  const { tracker, calls } = trackerOf(() => Promise.reject(error))
+  await assert.rejects(tracker.snapshotFor('claude', 'a1'), error)
+  await assert.rejects(tracker.snapshotFor('claude', 'a1', true), error)
+  assert.equal(calls.count, 1, 'force must not punch through an active cooldown')
+})
+
+test('snapshotFor: force bypasses a fresh SUCCESS cache for an honest re-check', async () => {
+  const { tracker, calls } = trackerOf(() => Promise.resolve(OK_USAGE))
+  await tracker.snapshotFor('claude', 'a1')
+  await tracker.snapshotFor('claude', 'a1')
+  assert.equal(calls.count, 1, 'plain calls reuse the fresh cache')
+  await tracker.snapshotFor('claude', 'a1', true)
+  assert.equal(calls.count, 2, 'a forced call re-fetches regardless of freshness')
+})
+
+test('snapshotFor: a provider without a usage fetcher answers supported:false', async () => {
+  const tracker = new PoolUsageTracker(() => undefined)
+  const usage = await tracker.snapshotFor('grok', 'a1')
+  assert.deepEqual(usage, { supported: false })
+})

--- a/test/pool.spec.ts
+++ b/test/pool.spec.ts
@@ -15,6 +15,7 @@ import { buildAccountPools, poolKey } from '../src/providers/pool-family.js'
 import type { PoolDefinition, PoolMemberRef, ProviderPoolSource } from '../src/providers/pool-family.js'
 import { memberKey, PoolHealthRegistry } from '../src/providers/pool-health.js'
 import { PoolUsageTracker } from '../src/providers/pool-usage.js'
+import { OAuthEndpointError } from '../src/providers/common.js'
 import type { ProviderUsage } from '../src/providers/common.js'
 import type { ProviderId } from '../src/auth/store.js'
 import type { AccountAwareAdapter } from '../src/providers/accounts.js'
@@ -521,6 +522,28 @@ test('stream: a transient failure does not invalidate the usage snapshot', async
   await collect(pool.stream(OPTIONS))
   await usage.quotaFor(member)
   assert.equal(usageCalls.length, 1)
+})
+
+test('stream: quota_aware selection never re-hits a usage endpoint still cooling down from a 429 (issue #46)', async () => {
+  // Every quota_aware stream() re-consults quotaFor for every usable member
+  // (see select() above), so a real completion loop calls it once per
+  // request. Anthropic's usage endpoint rate-limits progressively — each hit
+  // inside the retry-after window pushes the next one further out — so
+  // retrying it on every request permanently locks the account out.
+  const usageCalls: string[] = []
+  const error = new OAuthEndpointError('claude usage token endpoint error (HTTP 429)', 429, undefined, 60_000)
+  const codex = new FakeAdapter((_options, account) => serveOk(account))
+  const { pool } = makePool({ codex }, {
+    strategy: 'quota_aware',
+    usage: (provider, account) => {
+      if (provider !== 'codex' || account !== 'a1') return undefined
+      return () => { usageCalls.push(account); return Promise.reject(error) }
+    },
+  })
+  await collect(pool.stream(OPTIONS))
+  await collect(pool.stream(OPTIONS))
+  await collect(pool.stream(OPTIONS))
+  assert.equal(usageCalls.length, 1, 'three requests in a row must cost at most one usage-endpoint hit')
 })
 
 test('stream: a caller abandoning the stream closes the member stream', async () => {

--- a/test/usage.spec.ts
+++ b/test/usage.spec.ts
@@ -20,9 +20,13 @@ const { fetchCodexUsage } = await import('../src/providers/codex.js')
 const { fetchClaudeUsage } = await import('../src/providers/claude.js')
 const { fetchGrokUsage, grokTierName } = await import('../src/providers/grok.js')
 const plugin = await import('../src/index.js')
+const { SubscriptionsAuthController } = plugin
+const { OAuthFlowManager } = await import('../src/auth/oauth-flow.js')
+const { DeviceFlowManager } = await import('../src/auth/device-flow.js')
+const { PoolUsageTracker } = await import('../src/providers/pool-usage.js')
 
 import { OAuthEndpointError } from '../src/providers/common.js'
-import type { FetchFn } from '../src/providers/common.js'
+import type { FetchFn, ProviderUsage } from '../src/providers/common.js'
 import type { ClaudeSession, CodexSession, GrokSession } from '../src/auth/store.js'
 
 const codexSession: CodexSession = {
@@ -313,4 +317,68 @@ test('usage endpoint: payload validation rejects unknown providers', async () =>
   const result = await handler('usage', { provider: 'gemini' }, new AbortController().signal)
   assert.equal(result.ok, false)
   if (!result.ok) assert.equal(result.error.code, 'bad-request')
+})
+
+test('usage endpoint: payload validation rejects a non-boolean force flag', async () => {
+  const handler = await mount()
+  const result = await handler('usage', { provider: 'codex', account: 'a1', force: 'yes' }, new AbortController().signal)
+  assert.equal(result.ok, false)
+  if (!result.ok) assert.equal(result.error.code, 'bad-request')
+})
+
+// ---------------------------------------------------------------------------
+// SubscriptionsAuthController.usage(): delegation to the pool's usage cache.
+// The RPC and mount() tests above only exercise the "no pool tracker yet"
+// (logged-out) path; these construct the controller directly, the way
+// login.spec.ts does, to prove the actual wiring fixed by issue #46 — a
+// failing usage fetch must not be retried through an active cooldown, and a
+// manual (forced) refresh must bypass a fresh cache without bypassing that
+// cooldown.
+// ---------------------------------------------------------------------------
+
+/** A usage fetcher the delegation tests assert is never reached once a pool tracker is wired in. */
+function unreachableFetcher(): Promise<ProviderUsage> {
+  throw new Error('the raw fetcher must not be called once the pool usage cache is wired in')
+}
+
+test('usage(): delegates to the pool usage cache, which withholds retries through a 429 cooldown', async () => {
+  let calls = 0
+  const error = new OAuthEndpointError('claude usage token endpoint error (HTTP 429)', 429, undefined, 60_000)
+  const poolUsage = new PoolUsageTracker((provider, account) =>
+    provider === 'codex' && account === 'a1' ? () => { calls += 1; return Promise.reject(error) } : undefined)
+  const controller = new SubscriptionsAuthController(
+    new OAuthFlowManager(), new DeviceFlowManager(), () => {}, () => undefined,
+    { codex: unreachableFetcher }, undefined, poolUsage,
+  )
+  await assert.rejects(controller.usage('codex', 'a1', new AbortController().signal), error)
+  assert.equal(calls, 1)
+  await assert.rejects(controller.usage('codex', 'a1', new AbortController().signal), error)
+  assert.equal(calls, 1, 'a second call inside the retry-after window must not hit the network again')
+})
+
+test('usage(): a manual (forced) refresh bypasses a fresh cached snapshot, not a live cooldown', async () => {
+  let calls = 0
+  const usage: ProviderUsage = { supported: true, windows: [] }
+  const poolUsage = new PoolUsageTracker((provider, account) =>
+    provider === 'codex' && account === 'a1' ? () => { calls += 1; return Promise.resolve(usage) } : undefined)
+  const controller = new SubscriptionsAuthController(
+    new OAuthFlowManager(), new DeviceFlowManager(), () => {}, () => undefined,
+    { codex: unreachableFetcher }, undefined, poolUsage,
+  )
+  await controller.usage('codex', 'a1', new AbortController().signal)
+  await controller.usage('codex', 'a1', new AbortController().signal)
+  assert.equal(calls, 1, 'a plain call reuses the fresh cache')
+  await controller.usage('codex', 'a1', new AbortController().signal, true)
+  assert.equal(calls, 2, 'a forced call re-checks despite the fresh cache')
+})
+
+test('usage(): with no pool tracker (pool disabled), every call hits the raw fetcher directly', async () => {
+  let calls = 0
+  const controller = new SubscriptionsAuthController(
+    new OAuthFlowManager(), new DeviceFlowManager(), () => {}, () => undefined,
+    { codex: async () => { calls += 1; return { supported: true, windows: [] } } },
+  )
+  await controller.usage('codex', 'a1', new AbortController().signal)
+  await controller.usage('codex', 'a1', new AbortController().signal)
+  assert.equal(calls, 2, 'unchanged prior behavior when the pool usage cache is unavailable')
 })

--- a/test/usage.spec.ts
+++ b/test/usage.spec.ts
@@ -21,6 +21,7 @@ const { fetchClaudeUsage } = await import('../src/providers/claude.js')
 const { fetchGrokUsage, grokTierName } = await import('../src/providers/grok.js')
 const plugin = await import('../src/index.js')
 
+import { OAuthEndpointError } from '../src/providers/common.js'
 import type { FetchFn } from '../src/providers/common.js'
 import type { ClaudeSession, CodexSession, GrokSession } from '../src/auth/store.js'
 
@@ -160,6 +161,18 @@ test('fetchClaudeUsage maps legacy buckets and skips null ones', async () => {
   })
   assert.equal(requests[0].headers['anthropic-beta'], 'oauth-2025-04-20')
   assert.equal(requests[0].headers.authorization, 'Bearer at')
+})
+
+test('fetchClaudeUsage: a 429 carries the retry-after header as retryAfterMs (issue #46)', async () => {
+  const fetchFn: FetchFn = ((_url: string | URL | Request, _init?: RequestInit) => Promise.resolve(
+    new Response(JSON.stringify({}), { status: 429, headers: { 'retry-after': '462' } }),
+  )) as FetchFn
+  await assert.rejects(fetchClaudeUsage(claudeSession, fetchFn), (error: unknown) => {
+    assert.ok(error instanceof OAuthEndpointError)
+    assert.equal(error.status, 429)
+    assert.equal(error.retryAfterMs, 462_000)
+    return true
+  })
 })
 
 test('fetchClaudeUsage prefers the modern limits array when present', async () => {


### PR DESCRIPTION
Fixes #46.

## What was happening

`PoolUsageTracker.refresh()` only wrote its cache (`entries`) on a
**successful** usage fetch. A rejected fetch left nothing behind, so the
next lookup for that account started a brand new network request — every
single time. Under the default `quota_aware` pool strategy, `select()`
calls `quotaFor()` for every usable member on **every completion request**,
so a failing usage endpoint got hit once per request, indefinitely.

Anthropic's `/api/oauth/usage` endpoint rate-limits progressively: each hit
inside an active `retry-after` window pushes the *next* window further out
(462s → 3600s in the issue's trace). Retrying on every request therefore
doesn't just fail to recover — it guarantees the account never gets a
chance to.

Two secondary issues compounded it:
- `oauthEndpointError()` (reused for usage/models fetches, not just real
  OAuth token exchanges) parsed the JSON error body but never read the
  `retry-after` header — unlike `httpLlmError()`, which already does this
  for the completions path.
- The Settings page's `usage` RPC called the raw fetcher directly,
  bypassing `PoolUsageTracker` entirely — so reopening the page could
  re-hit an endpoint that was still cooling down from the pool's own
  attempt.

## What changed

- **`src/providers/pool-usage.ts`** — `entries` is now a discriminated
  union (`SnapshotEntry | FailureEntry`). A failure is cached too, using
  the endpoint's own `retry-after` as the cooldown when it sent one
  (`OAuthEndpointError.retryAfterMs`), else the existing 5-minute TTL.
  Missing/invalid-credential errors are the deliberate exception — they
  cost no network round trip (the session lookup fails before the request
  goes out), so they stay live-checked on every call instead of being
  cached; a fixed login rejoins routing immediately rather than waiting
  out a stale cooldown. Added `snapshotFor()`, a cache-sharing sibling of
  `quotaFor()` that returns the raw snapshot (or rethrows the cached
  error) for direct display instead of a routing score.
- **`src/providers/common.ts`** — `OAuthEndpointError` now carries
  `retryAfterMs`, parsed from the response the same way `httpLlmError`
  already does.
- **`src/index.ts` / `src/auth/rpc.ts`** — `SubscriptionsAuthController.usage()`
  now routes through the pool's `PoolUsageTracker` when the pool is
  enabled (falls back to the raw fetcher when it isn't, unchanged prior
  behavior). Added an optional `force` flag on the `usage` RPC: a manual
  Refresh click sends `force: true`, which bypasses a *fresh* cached
  snapshot for an honest re-check, but — critically — never bypasses an
  active failure cooldown. Retrying through the cooldown from the UI is
  exactly the behavior that caused the lockout in the first place.
- **`src/client/SubscriptionsSection.tsx`** — threads that `force` flag
  from the manual Refresh button; the passive auto-load effect is
  unchanged (it already correctly avoids retrying a failed lookup within
  one mount — traced through `dropStale`'s same-reference bail-out — so
  no change was needed there).

## How to verify

**Automated:**
```
pnpm test
```
Adds/updates:
- `test/pool-usage.spec.ts` (new) — `PoolUsageTracker` unit tests: a 429
  with `retry-after` is cached and not retried inside the window; a
  failure with no `retry-after` falls back to the default TTL and *does*
  retry once it expires; a missing/invalid credential is never
  negative-cached; a stale success still serves cached data while
  triggering exactly one background refresh; `snapshotFor()`'s failure
  cooldown is never bypassed even by a forced call, while a forced call
  does bypass a fresh success cache.
- `test/usage.spec.ts` — `fetchClaudeUsage` on a 429 now carries
  `retryAfterMs` from the `retry-after` header; `SubscriptionsAuthController.usage()`
  delegation tests (pool-enabled cooldown, forced refresh, pool-disabled
  fallback); RPC payload validation for the new `force` flag.
- `test/pool.spec.ts` — an end-to-end case through the actual completion
  path: three `pool.stream()` calls in a row under `quota_aware` against
  an account whose usage fetcher always 429s costs at most **one** real
  hit to the endpoint, not one per request.

Note: this repo's own `package.json`/`pnpm-lock.yaml` currently pin the
`@deepseek-ai/*` workspace deps to `link:/Users/v1ki/Documents/projs/...`
— a path that only exists on the original author's machine. `pnpm install`
doesn't error on that; it silently produces dangling symlinks for anyone
else, so `pnpm test`/`pnpm build` can't run as-is on a fresh clone. All of
those packages are also published on the public npm registry at matching
versions (e.g. `@deepseek-ai/dsh-llm@0.1.1-rc.2`), which is how this PR's
suite was actually run and verified — 283 tests, 277 pass, 0 fail, 6
skipped (pre-existing, gated on a local macOS Keychain entry, unrelated to
this change), plus a clean `pnpm build`. Happy to send a tiny separate PR
repointing those to the published versions if useful — didn't want to
bundle an unrelated dependency change into this fix.

**Manual, per the issue's repro:** with a pooled Claude account that's hit
`/api/oauth/usage`'s rate limit, confirm the endpoint is no longer
re-hit on every chat request or every Settings-page load — only once per
`retry-after` window, and the account eventually recovers instead of the
window growing indefinitely.