### PR TITLE
fix: migrate to the dsh 0.1.2-alpha.1 APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "client": {
       "platform": "web",
       "inject": [
-        "@deepseek-ai/dsh-client-runtime",
+        "@deepseek-ai/dsh-client-ui-renderer",
         "@deepseek-ai/dsh-client-ui-settings",
         "@deepseek-ai/dsh-client-locale"
       ]
@@ -57,10 +57,10 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+    "@deepseek-ai/dsh-attachment": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-home-paths": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-llm": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-tools": "^0.1.2-alpha.1",
     "@deepseek-ai/schemastery": "^3.18.1"
   },
   "devDependencies": {
@@ -69,13 +69,12 @@
     "@deepseek-ai/dsh-attachment": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/attachment/attachment",
     "@deepseek-ai/dsh-client-connection": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/client/connection",
     "@deepseek-ai/dsh-client-locale": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/client/locale",
-    "@deepseek-ai/dsh-client-runtime": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/client/runtime",
     "@deepseek-ai/dsh-client-ui-settings": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/client/ui-settings",
     "@deepseek-ai/dsh-client-ui-conversation": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/client/ui-conversation",
     "@deepseek-ai/dsh-client-ui-commands": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/client/ui-commands",
+    "@deepseek-ai/dsh-client-ui-renderer": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/client/ui-renderer",
     "@deepseek-ai/dsh-client-ui-slots": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/client/ui-slots",
     "@deepseek-ai/dsh-home-paths": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/util/home-paths",
-    "@deepseek-ai/dsh-host-apiproxy": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/host/apiproxy",
     "@deepseek-ai/dsh-llm": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/llm/llm",
     "@deepseek-ai/dsh-tools": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/packages/core/tools",
     "@deepseek-ai/schemastery": "link:/Users/v1ki/Documents/projs/source/deepseek-harness/vendor/schemastery",

--- a/src/auth/rpc.ts
+++ b/src/auth/rpc.ts
@@ -7,7 +7,7 @@
 
 import type { Context } from '@deepseek-ai/cordis'
 import type { HostConnectionHandle } from '@deepseek-ai/dsh-client-connection'
-import type { RpcResult } from '@deepseek-ai/dsh-host-apiproxy/api'
+import type { ConnectionRpcResult as RpcResult } from '@deepseek-ai/dsh-client-connection'
 import { AttachmentId } from '@deepseek-ai/dsh-attachment'
 import type { ImageAttachmentRef } from '@deepseek-ai/dsh-attachment'
 import { PROVIDER_IDS, type ProviderId } from './store.js'
@@ -489,7 +489,6 @@ export function registerAuthRpc(
             return failure(error)
           }
         },
-        { authority: 'loopback' },
       ),
       'dsh-plugin-subscriptions: /subscriptions-auth rpc channel',
     )

--- a/src/client/ImageGenerateToolview.tsx
+++ b/src/client/ImageGenerateToolview.tsx
@@ -15,7 +15,7 @@
  */
 import type { CSSProperties } from 'react'
 import type { ConnectionHandle, RpcResult } from '@deepseek-ai/dsh-api-remotes/client'
-import type { ToolCallBlock } from '@deepseek-ai/dsh-client-runtime/client'
+import type { ToolCallBlock } from '@deepseek-ai/dsh-client-ui-conversation/client'
 import { IconSparkle16 } from '@deepseek-ai/dsh-client-ui-primitives'
 import { ImageGallery } from './ImageGallery.js'
 import type { ImageAttachmentRef, ImageLoader, MessageImageLabels } from './ImageGallery.js'

--- a/src/client/VideoGenerateToolview.tsx
+++ b/src/client/VideoGenerateToolview.tsx
@@ -16,7 +16,7 @@
 import { useEffect, useState } from 'react'
 import type { CSSProperties } from 'react'
 import type { ConnectionHandle, RpcResult } from '@deepseek-ai/dsh-api-remotes/client'
-import type { ToolCallBlock } from '@deepseek-ai/dsh-client-runtime/client'
+import type { ToolCallBlock } from '@deepseek-ai/dsh-client-ui-conversation/client'
 import { IconSparkle16 } from '@deepseek-ai/dsh-client-ui-primitives'
 import { en } from './locales.js'
 import type { SubscriptionsKey } from './locales.js'

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -6,7 +6,8 @@
  * namespace with zh/en dictionaries, rebound per read so the nav label and
  * page text follow the active locale.
  */
-import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+import type {} from '@deepseek-ai/dsh-client-ui-renderer/client'
+import type { Context as ClientContext } from '@deepseek-ai/cordis'
 import type { ConnectionHandle, SessionId } from '@deepseek-ai/dsh-api-remotes/client'
 // Type-only: pulls the shell's SlotMap merge (the 'settings.section' entry).
 import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
@@ -126,7 +127,7 @@ export function apply(ctx: ClientContext): void {
   // stays listed everywhere; `options` throws the friendly gate when the
   // session's current model is not a fast-capable codex model (the same
   // in-popup error posture the /model contribution uses for its guards).
-  ctx.inject(['commandUi'], (scope) => {
+  ctx.inject(['commandUi'], (scope: ClientContext) => {
     const command = scope.get('commandUi') as CommandUiContract
     scope.effect(() => command.register({
       name: 'fast',

--- a/src/translate/anthropic.ts
+++ b/src/translate/anthropic.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  CallId,
+  ToolCallId,
   CONTEXT_WINDOW_EXCEEDED_CODE,
   EMPTY_RESPONSE_CODE,
   LlmError,
@@ -311,7 +311,7 @@ function closeBlock(block: OpenBlock): ContentBlock {
     case 'tool-call':
       return {
         type: 'tool-call',
-        id: CallId(block.callId),
+        id: ToolCallId(block.callId),
         name: block.name ?? '',
         arguments: block.text,
       }
@@ -422,7 +422,7 @@ export class AnthropicStreamTranslator {
             chunks.push({
               type: 'tool-call-delta',
               index: opened.index,
-              id: CallId(opened.callId),
+              id: ToolCallId(opened.callId),
               ...block.name === undefined ? {} : { name: block.name },
               argumentsDelta: '',
             })
@@ -452,7 +452,7 @@ export class AnthropicStreamTranslator {
             chunks.push({
               type: 'tool-call-delta',
               index: block.index,
-              id: CallId(block.callId),
+              id: ToolCallId(block.callId),
               ...block.name === undefined ? {} : { name: block.name },
               argumentsDelta: delta.partial_json ?? '',
             })

--- a/src/translate/chat-completions.ts
+++ b/src/translate/chat-completions.ts
@@ -6,7 +6,7 @@
  * translator, so tests need no streams.
  */
 
-import { CallId, EMPTY_RESPONSE_CODE, LlmError } from '@deepseek-ai/dsh-llm'
+import { EMPTY_RESPONSE_CODE, LlmError, ToolCallId } from '@deepseek-ai/dsh-llm'
 import type {
   ContentBlock,
   StreamChunk,
@@ -203,7 +203,7 @@ function closeBlock(block: OpenBlock): ContentBlock {
     case 'tool-call':
       return {
         type: 'tool-call',
-        id: CallId(block.callId),
+        id: ToolCallId(block.callId),
         name: block.name ?? '',
         arguments: block.text,
       }
@@ -338,7 +338,7 @@ export class ChatCompletionsStreamTranslator {
           chunks.push({
             type: 'tool-call-delta',
             index: block.index,
-            id: CallId(block.callId),
+            id: ToolCallId(block.callId),
             ...block.name === undefined ? {} : { name: block.name },
             argumentsDelta: '',
           })
@@ -348,7 +348,7 @@ export class ChatCompletionsStreamTranslator {
           chunks.push({
             type: 'tool-call-delta',
             index: block.index,
-            id: CallId(block.callId),
+            id: ToolCallId(block.callId),
             argumentsDelta: call.function.arguments,
           })
         }

--- a/src/translate/responses.ts
+++ b/src/translate/responses.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  CallId,
+  ToolCallId,
   CONTEXT_WINDOW_EXCEEDED_CODE,
   EMPTY_RESPONSE_CODE,
   isContextWindowExceededError,
@@ -274,7 +274,7 @@ function closeBlock(block: OpenBlock): ContentBlock {
     case 'tool-call':
       return {
         type: 'tool-call',
-        id: CallId(block.callId),
+        id: ToolCallId(block.callId),
         name: block.name ?? '',
         arguments: block.text,
       }
@@ -365,7 +365,7 @@ export class ResponsesStreamTranslator {
           chunks.push({
             type: 'tool-call-delta',
             index: block.index,
-            id: CallId(callId),
+            id: ToolCallId(callId),
             ...item.name === undefined ? {} : { name: item.name },
             argumentsDelta: '',
           })
@@ -400,7 +400,7 @@ export class ResponsesStreamTranslator {
         chunks.push({
           type: 'tool-call-delta',
           index: block.index,
-          id: CallId(block.callId),
+          id: ToolCallId(block.callId),
           ...block.name === undefined ? {} : { name: block.name },
           argumentsDelta: event.delta ?? '',
         })

--- a/test/chat-completions.spec.ts
+++ b/test/chat-completions.spec.ts
@@ -7,7 +7,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { CallId, LlmError, MessageId } from '@deepseek-ai/dsh-llm'
+import { ToolCallId, LlmError, MessageId } from '@deepseek-ai/dsh-llm'
 import type { ContentBlock, Message, MessageSource, StreamChunk } from '@deepseek-ai/dsh-llm'
 import {
   ChatCompletionsStreamTranslator,
@@ -34,13 +34,13 @@ function message(
 }
 
 function toolCall(id: string, name: string, args: string): ContentBlock {
-  return { type: 'tool-call', id: CallId(id), name, arguments: args }
+  return { type: 'tool-call', id: ToolCallId(id), name, arguments: args }
 }
 
 function toolResult(callId: string, text: string): ContentBlock {
   return {
     type: 'tool-result',
-    toolCallId: CallId(callId),
+    toolCallId: ToolCallId(callId),
     content: [{ type: 'text', text }],
   }
 }
@@ -57,7 +57,7 @@ test('toChatMessages: text, tool call, and tool result round trip', () => {
       { type: 'text', text: 'running ls' },
       toolCall('call-1', 'bash', '{"cmd":"ls"}'),
     ]),
-    message('user', [toolResult('call-1', 'file-a\nfile-b')], { kind: 'tool', callId: CallId('call-1') }),
+    message('user', [toolResult('call-1', 'file-a\nfile-b')], { kind: 'tool', callId: ToolCallId('call-1') }),
   ], 'be helpful')
 
   assert.deepEqual(messages, [
@@ -173,10 +173,10 @@ test('translator: tool call fragments assemble into one tool-call block', () => 
   const terminal = translator.flush()
   assert.deepEqual(chunks, [
     { type: 'block-start', index: 0, blockType: 'tool-call' },
-    { type: 'tool-call-delta', index: 0, id: CallId('call-1'), name: 'bash', argumentsDelta: '' },
-    { type: 'tool-call-delta', index: 0, id: CallId('call-1'), argumentsDelta: '{"cmd"' },
-    { type: 'tool-call-delta', index: 0, id: CallId('call-1'), argumentsDelta: ':"ls"}' },
-    { type: 'block-end', index: 0, block: { type: 'tool-call', id: CallId('call-1'), name: 'bash', arguments: '{"cmd":"ls"}' } },
+    { type: 'tool-call-delta', index: 0, id: ToolCallId('call-1'), name: 'bash', argumentsDelta: '' },
+    { type: 'tool-call-delta', index: 0, id: ToolCallId('call-1'), argumentsDelta: '{"cmd"' },
+    { type: 'tool-call-delta', index: 0, id: ToolCallId('call-1'), argumentsDelta: ':"ls"}' },
+    { type: 'block-end', index: 0, block: { type: 'tool-call', id: ToolCallId('call-1'), name: 'bash', arguments: '{"cmd":"ls"}' } },
   ])
   assert.deepEqual(terminal, [{ type: 'finish', reason: { kind: 'tool-calls' } }])
 })

--- a/test/copilot.spec.ts
+++ b/test/copilot.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { CallId, MessageId, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import { ToolCallId, MessageId, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { GenerateOptions } from '@deepseek-ai/dsh-llm'
 import {
   completeCopilotLogin,
@@ -674,15 +674,15 @@ function toolRoundTripHistory(callId = 'call_A'): GenerateOptions['messages'] {
       role: 'assistant',
       content: [
         { type: 'reasoning', text: 'thinking' },
-        { type: 'tool-call', id: CallId(callId), name: 'bash', arguments: '{"cmd":"ls"}' },
+        { type: 'tool-call', id: ToolCallId(callId), name: 'bash', arguments: '{"cmd":"ls"}' },
       ],
       source: { kind: 'model', provider: 'copilot', model: 'gpt-5.6-sol' },
     },
     {
       id: MessageId('m-b'),
       role: 'user',
-      content: [{ type: 'tool-result', toolCallId: CallId(callId), content: [{ type: 'text', text: 'file-a' }] }],
-      source: { kind: 'tool', callId: CallId(callId) },
+      content: [{ type: 'tool-result', toolCallId: ToolCallId(callId), content: [{ type: 'text', text: 'file-a' }] }],
+      source: { kind: 'tool', callId: ToolCallId(callId) },
     },
   ]
 }
@@ -696,15 +696,15 @@ function twoRoundHistory(): GenerateOptions['messages'] {
       role: 'assistant',
       content: [
         { type: 'reasoning', text: 'thinking more' },
-        { type: 'tool-call', id: CallId('call_B'), name: 'grep', arguments: '{"q":"x"}' },
+        { type: 'tool-call', id: ToolCallId('call_B'), name: 'grep', arguments: '{"q":"x"}' },
       ],
       source: { kind: 'model', provider: 'copilot', model: 'gpt-5.6-sol' },
     },
     {
       id: MessageId('m-d'),
       role: 'user',
-      content: [{ type: 'tool-result', toolCallId: CallId('call_B'), content: [{ type: 'text', text: 'match' }] }],
-      source: { kind: 'tool', callId: CallId('call_B') },
+      content: [{ type: 'tool-result', toolCallId: ToolCallId('call_B'), content: [{ type: 'text', text: 'match' }] }],
+      source: { kind: 'tool', callId: ToolCallId('call_B') },
     },
   ]
 }

--- a/test/login.spec.ts
+++ b/test/login.spec.ts
@@ -19,7 +19,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Context } from '@deepseek-ai/cordis'
 import type { ConnectionRpcHandler } from '@deepseek-ai/dsh-client-connection'
-import type { RpcResult } from '@deepseek-ai/dsh-host-apiproxy/api'
+import type { ConnectionRpcResult as RpcResult } from '@deepseek-ai/dsh-client-connection'
 
 import * as plugin from '../src/index.js'
 import { SubscriptionsAuthController } from '../src/index.js'

--- a/test/model-defaults-rpc.spec.ts
+++ b/test/model-defaults-rpc.spec.ts
@@ -14,7 +14,7 @@ import { join } from 'node:path'
 import { Context } from '@deepseek-ai/cordis'
 import { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { ConnectionRpcHandler } from '@deepseek-ai/dsh-client-connection'
-import type { RpcResult } from '@deepseek-ai/dsh-host-apiproxy/api'
+import type { ConnectionRpcResult as RpcResult } from '@deepseek-ai/dsh-client-connection'
 
 const HOME = mkdtempSync(join(tmpdir(), 'model-defaults-rpc-test-'))
 

--- a/test/rpc.spec.ts
+++ b/test/rpc.spec.ts
@@ -12,7 +12,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Context } from '@deepseek-ai/cordis'
 import type { ConnectionRpcHandler } from '@deepseek-ai/dsh-client-connection'
-import type { RpcResult } from '@deepseek-ai/dsh-host-apiproxy/api'
+import type { ConnectionRpcResult as RpcResult } from '@deepseek-ai/dsh-client-connection'
 
 process.env.DSH_HOME = mkdtempSync(join(tmpdir(), 'router-rpc-test-'))
 

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -6,7 +6,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { CallId, LlmError, MessageId } from '@deepseek-ai/dsh-llm'
+import { ToolCallId, LlmError, MessageId } from '@deepseek-ai/dsh-llm'
 import type { ContentBlock, Message, MessageSource, StreamChunk } from '@deepseek-ai/dsh-llm'
 import {
   ResponsesStreamTranslator,
@@ -40,13 +40,13 @@ function message(
 }
 
 function toolCall(id: string, name: string, args: string): ContentBlock {
-  return { type: 'tool-call', id: CallId(id), name, arguments: args }
+  return { type: 'tool-call', id: ToolCallId(id), name, arguments: args }
 }
 
 function toolResult(callId: string, text: string, isError?: boolean): ContentBlock {
   return {
     type: 'tool-result',
-    toolCallId: CallId(callId),
+    toolCallId: ToolCallId(callId),
     content: [{ type: 'text', text }],
     ...isError === undefined ? {} : { isError },
   }
@@ -64,7 +64,7 @@ test('toResponsesInput: text, tool call, and tool result round trip', () => {
       { type: 'text', text: 'running ls' },
       toolCall('call-1', 'bash', '{"cmd":"ls"}'),
     ]),
-    message('user', [toolResult('call-1', 'file-a\nfile-b')], { kind: 'tool', callId: CallId('call-1') }),
+    message('user', [toolResult('call-1', 'file-a\nfile-b')], { kind: 'tool', callId: ToolCallId('call-1') }),
   ], 'be helpful')
 
   assert.equal(instructions, 'be helpful')
@@ -351,9 +351,9 @@ test('toAnthropicMessages: merged user message keeps tool_result blocks in one l
   // at the front or the request is rejected for an unanswered call.
   const messages = toAnthropicMessages([
     message('assistant', [toolCall('call-1', 'bash', '{}'), toolCall('call-2', 'bash', '{}')]),
-    message('user', [toolResult('call-1', 'first')], { kind: 'tool', callId: CallId('call-1') }),
+    message('user', [toolResult('call-1', 'first')], { kind: 'tool', callId: ToolCallId('call-1') }),
     message('user', [{ type: 'text', text: 'spliced notice' }]),
-    message('user', [toolResult('call-2', 'second')], { kind: 'tool', callId: CallId('call-2') }),
+    message('user', [toolResult('call-2', 'second')], { kind: 'tool', callId: ToolCallId('call-2') }),
   ])
   assert.deepEqual(messages[1], {
     role: 'user',

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -30,7 +30,7 @@ const CLIENT_EXTERNALS: readonly string[] = [
  * Wire/type layers a client bundle may inline: browser-safe contracts
  * with no runtime identity to share (no Symbol/instanceof/singleton state).
  */
-const INLINE_SAFE = /^@deepseek-ai\/dsh-(host-apiproxy|session|llm|tools|brand)(\/|$)/
+const INLINE_SAFE = /^@deepseek-ai\/dsh-(session|llm|tools|brand)(\/|$)/
 
 /** Vendored framework libraries: ordinary libraries a browser bundle inlines. */
 const VENDORED_LIBRARY = /^@deepseek-ai\/(cosmokit|schemastery)(\/|$)/


### PR DESCRIPTION
## Why

On dsh `0.1.2-alpha.1` the published build does not load at all. The bundle carries

```js
import { …, CallId, … } from "@deepseek-ai/dsh-llm";
```

and the alpha exports `ToolCallId` instead, so this is an ESM link-time failure, not a degraded feature — the plugin's entry never evaluates and a profile that lists it fails to boot.

## What changed

- **`dsh-llm`: `CallId` → `ToolCallId`** — source and tests.
- **`dsh-host-apiproxy` is gone** (`packages/host/apiproxy` → `packages/api/gateway` + `packages/api/remotes`). `RpcResult` now comes from `dsh-client-connection` as `ConnectionRpcResult`. The Toolview components already imported from `dsh-api-remotes/client`; this finishes the move for `src/auth/rpc.ts` and the RPC specs.
- **`rpc.handle()` lost its per-channel `{ authority }` option.** The trust fence moved to the connection plugin's deployment-level `trustedHosts` config plus its Host/origin check (`packages/client/connection/src/api-request-trust.ts`), so dropping the argument preserves the loopback intent rather than widening it.
- **`dsh-client-runtime` is gone**: `ClientContext` is plain cordis `Context`, `ToolCallBlock` ships from `dsh-client-ui-conversation/client`, and the `slots` registry arrives through the `dsh-client-ui-renderer` Context augmentation — the empty-type-import idiom dsh's own client plugins use (e.g. `packages/client/ui-agent-preset`).
- **`dsh.client.inject` named `@deepseek-ai/dsh-client-runtime`**, a package the alpha no longer ships; it is replaced by `@deepseek-ai/dsh-client-ui-renderer`, which is what actually provides `slots` now. No package in the alpha injects `dsh-client-runtime` any more.
- devDependencies follow: `dsh-client-ui-renderer` added, `dsh-host-apiproxy` and `dsh-client-runtime` removed, and `host-apiproxy` leaves the bundler's `INLINE_SAFE` list.

## Compatibility

Peer ranges move to `^0.1.2-alpha.1`. One build cannot cover both releases: a range carrying a prerelease tag only matches prereleases of the same version, and the `CallId` rename would need a runtime lookup shim (`llm.ToolCallId ?? llm.CallId`) to satisfy `0.1.1-rc.2` as well. Happy to add that shim instead if you would rather keep one build working on both.

## Verification

Against a `dsh-v0.1.2-alpha.1` source build (`pnpm install && pnpm run build` in the harness checkout, its packages linked into `node_modules`):

- `tsc -p tsconfig.json --noEmit` — clean
- `tsc -p tsconfig.test.json` — clean
- `node --test lib-test/test/` — **320 passed, 0 failed, 6 skipped**
- `tsdown` — client bundle builds (96.28 kB)
- Mounted in a real `dsh --profile headless` boot on the alpha: the plugin loads and reaches its own `MISSING_CREDENTIAL` gate, where before the fix the profile failed at module link time.

https://claude.ai/code/session_019pK5Fn1JmB3Xo8RTzwQVd3