### PR TITLE
fix(grok): 兼容账单接口缺省 creditUsagePercent 时正常解析配额周期与重置时间

### DIFF
--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -352,12 +352,15 @@ export async function fetchGrokUsage(
   const payload = await response.json() as { config?: GrokBillingConfig | null; subscriptionTier?: string }
   const config = typeof payload.config === 'object' && payload.config !== null ? payload.config : {}
   const windows: UsageWindow[] = []
-  if (typeof config.creditUsagePercent === 'number' && Number.isFinite(config.creditUsagePercent)) {
+  if (config.currentPeriod || (typeof config.creditUsagePercent === 'number' && Number.isFinite(config.creditUsagePercent))) {
     const kind: UsageWindow['kind'] = config.currentPeriod?.type === 'USAGE_PERIOD_TYPE_WEEKLY'
       ? 'weekly'
       : 'other'
     const resetsAt = grokResetsAt(config.currentPeriod?.end)
-    windows.push({ kind, usedPercent: config.creditUsagePercent, ...resetsAt === undefined ? {} : { resetsAt } })
+    const usedPercent = typeof config.creditUsagePercent === 'number' && Number.isFinite(config.creditUsagePercent)
+      ? config.creditUsagePercent
+      : 0
+    windows.push({ kind, usedPercent, ...resetsAt === undefined ? {} : { resetsAt } })
   } else if (typeof config.monthlyLimit?.val === 'number' && config.monthlyLimit.val > 0) {
     const used = typeof config.used?.val === 'number' ? config.used.val : 0
     const resetsAt = grokResetsAt(config.billingPeriodEnd)

--- a/test/usage.spec.ts
+++ b/test/usage.spec.ts
@@ -276,6 +276,20 @@ test('fetchGrokUsage tolerates a null config and non-2xx responses', async () =>
   await assert.rejects(fetchGrokUsage(grokSession, failing), /grok billing/)
 })
 
+test('fetchGrokUsage extracts reset window when creditUsagePercent is absent but currentPeriod is present', async () => {
+  const { fetchFn } = fakeFetch({
+    config: {
+      currentPeriod: { type: 'USAGE_PERIOD_TYPE_WEEKLY', end: '2026-09-10T12:00:00Z' },
+    },
+  })
+  const usage = await fetchGrokUsage(grokSession, fetchFn)
+  assert.ok(usage.windows)
+  assert.equal(usage.windows.length, 1)
+  assert.equal(usage.windows[0]?.kind, 'weekly')
+  assert.equal(usage.windows[0]?.usedPercent, 0)
+  assert.equal(usage.windows[0]?.resetsAt, Date.parse('2026-09-10T12:00:00Z'))
+})
+
 /** Mount the plugin with fake llm/connection; return the RPC handler. */
 async function mount(): Promise<ConnectionRpcHandler> {
   let handler: ConnectionRpcHandler | undefined


### PR DESCRIPTION
## 背景与问题

目前在 `fetchGrokUsage`（`src/providers/grok.ts:355`）中，解析周限额窗口强依赖于 `creditUsagePercent` 字段必须为有效的数字类型：

```typescript
if (typeof config.creditUsagePercent === 'number' && Number.isFinite(config.creditUsagePercent)) {
  ...
}
```

但在真实的 xAI 线上账单接口（`https://cli-chat-proxy.grok.com/v1/billing?format=credits`）中，对于**未产生扣费消耗、当周刚重置或部分新订阅账号**，xAI 返回的 payload 中：
- 能够正常返回 `currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY", end: "..." }`；
- 但 `creditUsagePercent` 字段可能为 `null`、`undefined` 或被直接省略。

由于上述严苛校验，代码会直接跳过提取，导致解析出的配额窗口 `windows` 为**空数组 `[]`**。在 DSH 前端界面上表现为完全看不到 Grok 的用量额度、无法显示当周用量进度条与重置倒计时。

## 解决方案

1. **放宽判断条件**：只要存在 `config.currentPeriod`（包含重置周期信息）或 `creditUsagePercent` 为有效数字，即判定为有效配额窗口；
2. **缺省保底处理**：当 `creditUsagePercent` 未提供时，`usedPercent` 保底默认为 `0`，并正常提取 `resetsAt`（周期重置时间戳）。

## 验证

- 在 `test/usage.spec.ts` 中补充了针对性单元测试：
  - 测试用例：`fetchGrokUsage extracts reset window when creditUsagePercent is absent but currentPeriod is present`
  - 验证当 payload 仅有 `currentPeriod` 时，能够正确提取出配额窗口（`kind: "weekly"`，`usedPercent: 0`，正确计算 `resetsAt`）；
- 全量测试通过：`pnpm test`（370/370 pass）；
- 打包构建通过：`pnpm build`（`tsc && tsdown` 零报错）。