### PR TITLE
fix(codex): use current client version for model discovery

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -393,7 +393,7 @@ export const CODEX_MODELS_URL = 'https://chatgpt.com/backend-api/codex/models'
  * list, while current codex CLI releases get the full catalog — keep this in
  * the range of current codex CLI releases.
  */
-export const CODEX_CLIENT_VERSION = '0.147.0'
+export const CODEX_CLIENT_VERSION = '0.153.4'
 
 /** The codex `/models` entry shape this plugin reads (subset of codex-rs `ModelInfo`). */
 interface CodexWireModel {

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict'
 import './keep-alive.js'
 import { MessageId, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { Message } from '@deepseek-ai/dsh-llm'
-import { CodexAdapter, codexRequestBody, fetchCodexModels } from '../src/providers/codex.js'
+import { CODEX_CLIENT_VERSION, CODEX_MODELS_URL, CodexAdapter, codexRequestBody, fetchCodexModels } from '../src/providers/codex.js'
 import { GrokAdapter } from '../src/providers/grok.js'
 import { ClaudeAdapter, claudeRequestBody } from '../src/providers/claude.js'
 import { CopilotAdapter, fetchCopilotModels } from '../src/providers/copilot.js'
@@ -23,6 +23,17 @@ import { withTimeout } from '../src/providers/common.js'
 const STATIC_CODEX = [{ id: 'gpt-5.1-codex', name: 'GPT-5.1 Codex' }]
 const STATIC_CLAUDE = [{ id: 'claude-opus-4-5', name: 'Claude Opus 4.5' }]
 const STATIC_GROK = [{ id: 'grok-4', name: 'Grok 4' }]
+
+test('Codex discovery sends the current client version', async () => {
+  let requestedUrl = ''
+  const fetchFn: FetchFn = ((url: string) => {
+    requestedUrl = url
+    return Promise.resolve(new Response(JSON.stringify({ models: [{ slug: 'model' }] })))
+  }) as FetchFn
+  await fetchCodexModels(codexSession, fetchFn)
+  assert.equal(requestedUrl, `${CODEX_MODELS_URL}?client_version=${CODEX_CLIENT_VERSION}`)
+  assert.equal(CODEX_CLIENT_VERSION, '0.153.4')
+})
 
 const codexSession: CodexSession = {
   accessToken: 'at',


### PR DESCRIPTION
## Summary
- update the Codex model discovery client version to `0.153.4`
- cover the exact `client_version` query sent to the live catalog endpoint

Closes #69

## Validation
- `CI=true pnpm test`
- 370 tests: 364 passed, 0 failed, 6 skipped (OAuth/network-dependent)