### PR TITLE
fix(responses): send strict: false on function tools

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -652,7 +652,7 @@ export function codexRequestBody(
     // This is request-shape consistency, not a claim that Codex rejects the
     // controls when no tools are supplied.
     ...options.tools !== undefined && options.tools.length > 0
-      ? { tools: toResponsesTools(options.tools), tool_choice: 'auto', parallel_tool_calls: true }
+      ? { tools: toResponsesTools(options.tools, { strict: false }), tool_choice: 'auto', parallel_tool_calls: true }
       : {},
     ...options.reasoningEffort !== undefined
       ? { reasoning: { effort: String(options.reasoningEffort), summary: 'auto' } }

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -470,7 +470,7 @@ export function copilotResponsesRequestBody(
     ...resolved.instructions !== undefined ? { instructions: resolved.instructions } : {},
     input: resolved.input,
     ...options.tools !== undefined && options.tools.length > 0
-      ? { tools: toResponsesTools(options.tools), tool_choice: 'auto' }
+      ? { tools: toResponsesTools(options.tools, { strict: false }), tool_choice: 'auto' }
       : {},
     ...options.maxTokens !== undefined ? { max_output_tokens: options.maxTokens } : {},
     // The Responses wire spells the effort nested; only advertised efforts

--- a/src/translate/responses.ts
+++ b/src/translate/responses.ts
@@ -163,6 +163,13 @@ export function toResponsesInput(
 
 /**
  * Map harness tool schemas to Responses function tools.
+ *
+ * `strict` is sent as `false` explicitly: the Responses API defaults function
+ * tools to strict mode, which demands every property be emitted on every call.
+ * Harness schemas mark optional fields by omitting them from `required` (and
+ * never as nullable), so under strict mode the model fills them all — e.g. a
+ * bash call carrying `sandbox_permissions` with no denial to justify it, which
+ * the harness rejects before anything runs.
  * @param tools - tool schemas from the request.
  * @returns Responses `tools` array entries.
  */
@@ -172,6 +179,7 @@ export function toResponsesTools(tools: readonly ToolSchema[]): Record<string, u
     name: tool.name,
     description: tool.description,
     parameters: tool.parameters,
+    strict: false,
   }))
 }
 

--- a/src/translate/responses.ts
+++ b/src/translate/responses.ts
@@ -164,22 +164,24 @@ export function toResponsesInput(
 /**
  * Map harness tool schemas to Responses function tools.
  *
- * `strict` is sent as `false` explicitly: the Responses API defaults function
- * tools to strict mode, which demands every property be emitted on every call.
- * Harness schemas mark optional fields by omitting them from `required` (and
- * never as nullable), so under strict mode the model fills them all — e.g. a
- * bash call carrying `sandbox_permissions` with no denial to justify it, which
- * the harness rejects before anything runs.
+ * OpenAI Responses may normalize schemas into strict mode when `strict` is
+ * omitted. Codex and Copilot opt out to preserve harness optional parameters;
+ * this does not prevent a model from voluntarily supplying optional fields.
+ * Other providers keep their existing defaults unless explicitly opted out.
  * @param tools - tool schemas from the request.
+ * @param options - provider-specific opt-out from strict schema normalization.
  * @returns Responses `tools` array entries.
  */
-export function toResponsesTools(tools: readonly ToolSchema[]): Record<string, unknown>[] {
+export function toResponsesTools(
+  tools: readonly ToolSchema[],
+  options: { strict?: false } = {},
+): Record<string, unknown>[] {
   return tools.map(tool => ({
     type: 'function',
     name: tool.name,
     description: tool.description,
     parameters: tool.parameters,
-    strict: false,
+    ...options.strict === undefined ? {} : { strict: options.strict },
   }))
 }
 

--- a/test/copilot.spec.ts
+++ b/test/copilot.spec.ts
@@ -216,7 +216,7 @@ test('copilotResponsesRequestBody maps the Responses wire shape', () => {
   )
   assert.equal('instructions' in bare, false)
   assert.equal('max_output_tokens' in bare, false)
-  assert.deepEqual(bare.tools, [{ type: 'function', name: 'bash', description: 'run', parameters: { type: 'object' } }])
+  assert.deepEqual(bare.tools, [{ type: 'function', name: 'bash', description: 'run', parameters: { type: 'object' }, strict: false }])
   assert.equal(bare.tool_choice, 'auto')
 })
 

--- a/test/request-body.spec.ts
+++ b/test/request-body.spec.ts
@@ -11,6 +11,7 @@ import type { GenerateOptions } from '@deepseek-ai/dsh-llm'
 import { MessageId } from '@deepseek-ai/dsh-llm'
 import { codexRequestBody, CodexAdapter, CODEX_API_URL } from '../src/providers/codex.js'
 import { grokRequestBody, GrokAdapter, GROK_API_URL } from '../src/providers/grok.js'
+import { copilotResponsesRequestBody } from '../src/providers/copilot.js'
 import { AccountTokenManager } from '../src/providers/accounts.js'
 import { toResponsesInput } from '../src/translate/responses.js'
 
@@ -32,6 +33,36 @@ function options(tools?: GenerateOptions['tools']): GenerateOptions {
 }
 
 const resolved = toResponsesInput([], 'judge')
+
+test('Responses providers preserve optional escalation fields and apply strict opt-out only where intended', () => {
+  const parameters = {
+    type: 'object',
+    properties: {
+      command: { type: 'string' },
+      description: { type: 'string' },
+      sandbox_permissions: { type: 'string', enum: ['workspace-write', 'danger-full-access'] },
+      justification: { type: 'string' },
+    },
+    required: ['command', 'description'],
+  }
+  const original = structuredClone(parameters)
+  const tool = { name: 'bash', description: 'Run a command', parameters }
+  const request = options([tool])
+  const bodies = [
+    ['codex', codexRequestBody(request, resolved, false)],
+    ['copilot', copilotResponsesRequestBody(request, resolved)],
+    ['grok', grokRequestBody(request, resolved)],
+  ] as const
+  for (const [provider, body] of bodies) {
+    const [mapped] = body.tools as Record<string, unknown>[]
+    assert.deepEqual(mapped.parameters, original, `${provider}: preserve optional, non-nullable fields`)
+    assert.deepEqual(mapped, {
+      type: 'function', name: 'bash', description: 'Run a command', parameters: original,
+      ...provider === 'grok' ? {} : { strict: false },
+    }, `${provider}: strict policy belongs to the provider`)
+  }
+  assert.deepEqual(parameters, original, 'request assembly must not mutate the harness schema')
+})
 
 test('grok: tool-less request carries no tool_choice / parallel_tool_calls', () => {
   const body = grokRequestBody(options(), resolved)

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -151,7 +151,7 @@ test('toResponsesInput: reasoningFor replays completed reasoning items ahead of 
 
 test('toResponsesTools maps to Responses function tools', () => {
   assert.deepEqual(toResponsesTools([{ name: 'bash', description: 'run', parameters: { type: 'object' } }]), [
-    { type: 'function', name: 'bash', description: 'run', parameters: { type: 'object' } },
+    { type: 'function', name: 'bash', description: 'run', parameters: { type: 'object' }, strict: false },
   ])
 })
 

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -150,7 +150,7 @@ test('toResponsesInput: reasoningFor replays completed reasoning items ahead of 
 })
 
 test('toResponsesTools maps to Responses function tools', () => {
-  assert.deepEqual(toResponsesTools([{ name: 'bash', description: 'run', parameters: { type: 'object' } }]), [
+  assert.deepEqual(toResponsesTools([{ name: 'bash', description: 'run', parameters: { type: 'object' } }], { strict: false }), [
     { type: 'function', name: 'bash', description: 'run', parameters: { type: 'object' }, strict: false },
   ])
 })


### PR DESCRIPTION
## Problem

In the reported Codex session, the model filled in every declared property on every observed tool call, including optional fields the harness expects to be omitted.

When `strict` is omitted, OpenAI Responses attempts to normalize compatible schemas into strict mode, with a non-strict fallback for incompatible schemas. The affected harness tools express optional parameters by leaving them out of `required`, without making those fields nullable. Strict normalization can therefore change their optional behavior. See the [OpenAI documentation](https://developers.openai.com/api/docs/guides/function-calling#strict-mode).

The failure was observed with DSH 0.1.2-rc.1, whose `bash` schema includes optional `sandbox_permissions` and `justification` fields for sandbox escalation. Those two are only valid as a one-shot retry of a command the sandbox just denied. When a model emits them unconditionally:

- the first call carries `justification: ""` → `Error: invalid justification: expected a non-empty sentence`
- every later call carries `sandbox_permissions: "workspace-write"` while the session already runs under `workspace-write` → `Error: sandbox escalation to "workspace-write" is not strictly wider than this call's current "workspace-write" mode`

The command never runs. Observed with `codex/gpt-6-astra` on DSH 0.1.2-rc.1: 22 consecutive `bash` calls in a single turn, every one rejected before execution, the agent stuck re-issuing the same `pwd && git status --short`.

## Evidence

One long session, same model and account throughout; the only thing that changed between windows is this patch. Counting tool calls that filled **all** declared properties, across every tool with 3+ parameters (`bash`, `read`, `grep`, `subagent`, …):

| window | build in the profile | calls filling every property |
| --- | --- | --- |
| before | 0.7.0 from npm | 107 / 107 (100%) |
| patch live | 0.7.0 + `strict: false` | 34 / 50 (68%) |
| patch reverted | 0.7.0 from npm | 23 / 23 (100%) |

Under the patch the model omits optional parameters normally — `bash` drops to 0% full-fill and the escalation errors stop. Reverting brings both back. The effect across multiple tools supports this explanation, although the session windows are not a fully controlled experiment.

## Fix

Explicitly send `strict: false` on function tools in the Codex and Copilot Responses request builders, preserving the harness schema and its optional fields. The shared translator leaves the field absent unless a provider opts out. Grok retains its previous request shape: xAI has different strict-schema semantics and treats fields omitted from `required` as optional.

This avoids OpenAI's automatic strict normalization; it does not guarantee that a model will never voluntarily supply an inappropriate optional argument. Making all harness schemas strict-compatible would require broader schema and runtime changes upstream. No sandbox validation or approval checks are bypassed.

## Validation

- `pnpm test`: 396 passed, 6 skipped, 0 failed.
- `pnpm build`: passed.
- Added a regression test using required command fields and optional, non-nullable escalation fields. It checks schema preservation and the final request policy for Codex, Copilot, and Grok.
- Independent maintainer API comparison using the exported session's bash schema, `gpt-6-astra`, medium reasoning, and `pwd && git status --short`: all three baseline calls supplied escalation arguments; all three patched calls omitted them. One baseline call requested `danger-full-access`. The returned commands were not executed. These were fresh requests, not a replay of the entire failing session.

Related: #7 tracks the same failure class and complementary DSH core improvements. This PR addresses the adapter's strict-normalization contribution, not every possible cause of unnecessary escalation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
